### PR TITLE
feat(#473): Password recovery — ts-email library, reset tokens, API, frontend

### DIFF
--- a/auth/password/backend/__package.json
+++ b/auth/password/backend/__package.json
@@ -36,7 +36,8 @@
     "@nu-art/db-api-shared": "?",
     "@nu-art/http-server": "?",
     "@nu-art/ts-common": "?",
-    "@nu-art/api-types": "?"
+    "@nu-art/api-types": "?",
+    "@nu-art/ts-email-backend": "?"
   },
   "devDependencies": {
     "@nu-art/testalot": "?",

--- a/auth/password/backend/src/main/ModuleBE_PasswordAuth.ts
+++ b/auth/password/backend/src/main/ModuleBE_PasswordAuth.ts
@@ -22,11 +22,17 @@ import {ModuleBE_AccountDB} from '@nu-art/user-account-backend';
 import {BaseSessionClaims, CollectSessionData, MemKey_AccountEmail, MemKey_AccountId, MemKey_DB_Session, ModuleBE_SessionDB} from '@nu-art/user-account-backend';
 import {ModuleBE_FailedLoginAttemptDB} from './_entity/failed-login-attempt/ModuleBE_FailedLoginAttemptDB.js';
 import {ModuleBE_PasswordCredentialDB} from './_entity/password-credentials/ModuleBE_PasswordCredentialDB.js';
+import {ModuleBE_PasswordResetTokenDB} from './_entity/password-reset-token/ModuleBE_PasswordResetTokenDB.js';
+import {ModuleBE_Email} from '@nu-art/ts-email-backend';
 
 type Config = {
 	canRegister: boolean
 	passwordAssertion?: PasswordAssertionConfig
 	ignorePasswordAssertion?: boolean
+	resetToken?: {
+		ttlMs?: number;
+		maxRequestsPerHour?: number;
+	}
 }
 
 export class ModuleBE_PasswordAuth_Class
@@ -36,6 +42,12 @@ export class ModuleBE_PasswordAuth_Class
 	constructor() {
 		super();
 		this.setDefaultConfig({canRegister: false});
+	}
+
+	async init() {
+		await super.init();
+		if (this.config.resetToken)
+			ModuleBE_PasswordResetTokenDB.setTokenConfig(this.config.resetToken);
 	}
 
 	async __collectSessionData(data: BaseSessionClaims) {
@@ -91,6 +103,53 @@ export class ModuleBE_PasswordAuth_Class
 				? undefined
 				: this.config.passwordAssertion
 		};
+	}
+
+	@ApiHandler(ApiDef_PasswordAuth.requestReset)
+	async requestReset(body: API_PasswordAuth['requestReset']['Body']): Promise<void> {
+		ModuleBE_AccountDB.impl.fixEmail(body);
+		const account = (await ModuleBE_AccountDB.query.custom({where: {email: body.email}, limit: 1}))[0];
+		if (!account) {
+			this.logDebug(`requestReset: no account for email='${body.email}', silent success`);
+			return;
+		}
+
+		const resetToken = await ModuleBE_PasswordResetTokenDB.createToken(account._id);
+		const resetUrl = `${process.env.FRONTEND_URL ?? ''}/reset-password?token=${resetToken.token}`;
+
+		await ModuleBE_Email.send({
+			from: {email: 'noreply@market-oracle.app', name: 'Market Oracle'},
+			to: [{email: body.email}],
+			subject: 'Password Reset Request',
+			html: `<p>Click <a href="${resetUrl}">here</a> to reset your password. This link expires in 24 hours.</p>`,
+			text: `Reset your password: ${resetUrl}`,
+		});
+	}
+
+	@ApiHandler(ApiDef_PasswordAuth.executeReset)
+	async executeReset(body: API_PasswordAuth['executeReset']['Body']): Promise<void> {
+		const resetToken = await ModuleBE_PasswordResetTokenDB.assertToken(body.token);
+
+		this.password.assertPasswordCheck({email: '', password: body.password, passwordCheck: body.passwordCheck});
+
+		const account = (await ModuleBE_AccountDB.query.custom({where: {_id: resetToken.accountId}, limit: 1}))[0];
+		if (!account)
+			throw HttpCodes._4XX.BAD_REQUEST('Invalid reset token');
+
+		const existingCredentials = await this.credentials.queryByAccountId(account._id);
+		const salt = generateHex(32);
+		if (existingCredentials) {
+			await ModuleBE_PasswordCredentialDB.set.item({
+				...existingCredentials,
+				salt,
+				saltedPassword: hashPasswordWithSalt(salt, body.password),
+			});
+		} else {
+			await this.credentials.create(account, body.password);
+		}
+
+		await ModuleBE_PasswordResetTokenDB.consumeToken(resetToken);
+		await ModuleBE_SessionDB.delete.where({accountId: account._id});
 	}
 
 	private credentials = {

--- a/auth/password/backend/src/main/_entity/password-reset-token/ModuleBE_PasswordResetTokenDB.ts
+++ b/auth/password/backend/src/main/_entity/password-reset-token/ModuleBE_PasswordResetTokenDB.ts
@@ -1,0 +1,76 @@
+import {generateHex, Hour} from '@nu-art/ts-common';
+import {ModuleBE_BaseDB} from '@nu-art/db-api-backend';
+import {DatabaseDef_PasswordResetToken, DB_PasswordResetToken, DBDef_PasswordResetToken} from '@nu-art/password-auth-shared';
+import {HttpCodes} from '@nu-art/api-types';
+import {DB_Account} from '@nu-art/user-account-shared';
+
+type Config = {
+	ttlMs: number;
+	maxRequestsPerHour: number;
+};
+
+export class ModuleBE_PasswordResetTokenDB_Class
+	extends ModuleBE_BaseDB<DatabaseDef_PasswordResetToken> {
+
+	private tokenConfig: Config = {ttlMs: 24 * Hour, maxRequestsPerHour: 3};
+
+	constructor() {
+		super(DBDef_PasswordResetToken);
+	}
+
+	setTokenConfig(config: Partial<Config>) {
+		Object.assign(this.tokenConfig, config);
+	}
+
+	async createToken(accountId: DB_Account['_id']): Promise<DB_PasswordResetToken> {
+		await this.assertRateLimit(accountId);
+		await this.invalidateExisting(accountId);
+
+		return this.create.item({
+			accountId,
+			token: generateHex(64),
+			expiresAt: Date.now() + this.tokenConfig.ttlMs,
+		});
+	}
+
+	async assertToken(token: string): Promise<DB_PasswordResetToken> {
+		const results = await this.query.custom({where: {token}, limit: 1});
+		const resetToken = results[0];
+		if (!resetToken)
+			throw HttpCodes._4XX.BAD_REQUEST('Invalid or expired reset token');
+
+		if (resetToken.consumedAt)
+			throw HttpCodes._4XX.BAD_REQUEST('Reset token has already been used');
+
+		if (resetToken.expiresAt < Date.now())
+			throw HttpCodes._4XX.BAD_REQUEST('Reset token has expired');
+
+		return resetToken;
+	}
+
+	async consumeToken(token: DB_PasswordResetToken): Promise<DB_PasswordResetToken> {
+		return this.set.item({...token, consumedAt: Date.now()});
+	}
+
+	async invalidateExisting(accountId: DB_Account['_id']): Promise<void> {
+		const existing = await this.query.custom({where: {accountId}});
+		const now = Date.now();
+		for (const token of existing) {
+			if (token.consumedAt)
+				continue;
+
+			await this.set.item({...token, consumedAt: now});
+		}
+	}
+
+	private async assertRateLimit(accountId: DB_Account['_id']): Promise<void> {
+		const oneHourAgo = Date.now() - Hour;
+		const recentTokens = await this.query.custom({
+			where: {accountId, __created: {$gt: oneHourAgo}},
+		});
+		if (recentTokens.length >= this.tokenConfig.maxRequestsPerHour)
+			throw HttpCodes._4XX.TOO_MANY_REQUESTS('Too many password reset requests. Please try again later.');
+	}
+}
+
+export const ModuleBE_PasswordResetTokenDB = new ModuleBE_PasswordResetTokenDB_Class();

--- a/auth/password/backend/src/main/_entity/password-reset-token/module-pack.ts
+++ b/auth/password/backend/src/main/_entity/password-reset-token/module-pack.ts
@@ -1,0 +1,4 @@
+import {createApisForDBModule} from '@nu-art/db-api-backend';
+import {ModuleBE_PasswordResetTokenDB} from './ModuleBE_PasswordResetTokenDB.js';
+
+export const ModulePackBE_PasswordResetTokenDB = [ModuleBE_PasswordResetTokenDB, createApisForDBModule(ModuleBE_PasswordResetTokenDB)];

--- a/auth/password/backend/src/main/index.ts
+++ b/auth/password/backend/src/main/index.ts
@@ -10,3 +10,6 @@ export * from './_entity/failed-login-attempt/module-pack.js';
 
 export * from './_entity/password-credentials/ModuleBE_PasswordCredentialDB.js';
 export * from './_entity/password-credentials/module-pack.js';
+
+export * from './_entity/password-reset-token/ModuleBE_PasswordResetTokenDB.js';
+export * from './_entity/password-reset-token/module-pack.js';

--- a/auth/password/backend/src/main/module-pack.ts
+++ b/auth/password/backend/src/main/module-pack.ts
@@ -3,10 +3,12 @@ import {ModuleBE_PasswordAuth} from './ModuleBE_PasswordAuth.js';
 import {ModulePackBE_LoginAttemptDB} from './_entity/login-attempts/module-pack.js';
 import {ModulePackBE_FailedLoginAttemptDB} from './_entity/failed-login-attempt/module-pack.js';
 import {ModulePackBE_PasswordCredentialDB} from './_entity/password-credentials/module-pack.js';
+import {ModulePackBE_PasswordResetTokenDB} from './_entity/password-reset-token/module-pack.js';
 
 export const ModulePackBE_PasswordAuth: Module[] = [
 	ModuleBE_PasswordAuth,
 	...ModulePackBE_LoginAttemptDB,
 	...ModulePackBE_FailedLoginAttemptDB,
 	...ModulePackBE_PasswordCredentialDB,
+	...ModulePackBE_PasswordResetTokenDB,
 ];

--- a/auth/password/frontend/src/main/ModuleFE_PasswordAuth.ts
+++ b/auth/password/frontend/src/main/ModuleFE_PasswordAuth.ts
@@ -41,6 +41,16 @@ class ModuleFE_PasswordAuth_Class
 		return undefined as unknown as API_PasswordAuth['getPasswordAssertionConfig']['Response'];
 	}
 
+	@ApiCaller(ApiDef_PasswordAuth.requestReset)
+	async requestReset(body: API_PasswordAuth['requestReset']['Body']): Promise<void> {
+		void body;
+	}
+
+	@ApiCaller(ApiDef_PasswordAuth.executeReset)
+	async executeReset(body: API_PasswordAuth['executeReset']['Body']): Promise<void> {
+		void body;
+	}
+
 	public passwordAssertionConfig = () => StorageKey_PasswordAssertionConfig.get();
 
 	private onPasswordAssertionConfig = async (ctx: ApiCallContext<API_PasswordAuth['getPasswordAssertionConfig']>) => {

--- a/auth/password/frontend/src/main/index.ts
+++ b/auth/password/frontend/src/main/index.ts
@@ -5,3 +5,5 @@ export * from './ui/Component_Login/Component_Login.js';
 export * from './ui/Component_Register.js';
 export * from './ui/Component_ChangePassword/Component_ChangePassword.js';
 export * from './ui/Component_LoginBlocked/Component_LoginBlocked.js';
+export * from './ui/Component_ForgotPassword/Component_ForgotPassword.js';
+export * from './ui/Component_ResetPassword/Component_ResetPassword.js';

--- a/auth/password/frontend/src/main/ui/Component_ForgotPassword/Component_ForgotPassword.tsx
+++ b/auth/password/frontend/src/main/ui/Component_ForgotPassword/Component_ForgotPassword.tsx
@@ -1,0 +1,46 @@
+import {useState} from 'react';
+import {ModuleFE_PasswordAuth} from '../../ModuleFE_PasswordAuth.js';
+
+export const Component_ForgotPassword = () => {
+	const [email, setEmail] = useState('');
+	const [submitted, setSubmitted] = useState(false);
+	const [error, setError] = useState<string>();
+	const [loading, setLoading] = useState(false);
+
+	const handleSubmit = async () => {
+		setError(undefined);
+		setLoading(true);
+		try {
+			await ModuleFE_PasswordAuth.requestReset({email});
+			setSubmitted(true);
+		} catch (e: any) {
+			setError(e.message ?? 'Failed to send reset email');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	if (submitted)
+		return (
+			<div className="forgot-password">
+				<h2>Check your email</h2>
+				<p>If an account exists for {email}, we sent a password reset link.</p>
+			</div>
+		);
+
+	return (
+		<div className="forgot-password">
+			<h2>Forgot Password</h2>
+			<input
+				type="email"
+				placeholder="Enter your email"
+				value={email}
+				onChange={e => setEmail(e.target.value)}
+			/>
+			{error && <p className="error">{error}</p>}
+			<button onClick={handleSubmit} disabled={loading || !email}>
+				{loading ? 'Sending...' : 'Send Reset Link'}
+			</button>
+		</div>
+	);
+};

--- a/auth/password/frontend/src/main/ui/Component_ResetPassword/Component_ResetPassword.tsx
+++ b/auth/password/frontend/src/main/ui/Component_ResetPassword/Component_ResetPassword.tsx
@@ -1,0 +1,64 @@
+import {useState} from 'react';
+import {ModuleFE_PasswordAuth} from '../../ModuleFE_PasswordAuth.js';
+
+type Props = {
+	token: string;
+	onSuccess?: () => void;
+};
+
+export const Component_ResetPassword = ({token, onSuccess}: Props) => {
+	const [password, setPassword] = useState('');
+	const [passwordCheck, setPasswordCheck] = useState('');
+	const [error, setError] = useState<string>();
+	const [loading, setLoading] = useState(false);
+	const [success, setSuccess] = useState(false);
+
+	const handleSubmit = async () => {
+		setError(undefined);
+		if (password !== passwordCheck) {
+			setError('Passwords do not match');
+			return;
+		}
+
+		setLoading(true);
+		try {
+			await ModuleFE_PasswordAuth.executeReset({token, password, passwordCheck});
+			setSuccess(true);
+			onSuccess?.();
+		} catch (e: any) {
+			setError(e.message ?? 'Failed to reset password');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	if (success)
+		return (
+			<div className="reset-password">
+				<h2>Password Reset</h2>
+				<p>Your password has been reset successfully. You can now log in.</p>
+			</div>
+		);
+
+	return (
+		<div className="reset-password">
+			<h2>Reset Password</h2>
+			<input
+				type="password"
+				placeholder="New password"
+				value={password}
+				onChange={e => setPassword(e.target.value)}
+			/>
+			<input
+				type="password"
+				placeholder="Confirm password"
+				value={passwordCheck}
+				onChange={e => setPasswordCheck(e.target.value)}
+			/>
+			{error && <p className="error">{error}</p>}
+			<button onClick={handleSubmit} disabled={loading || !password || !passwordCheck}>
+				{loading ? 'Resetting...' : 'Reset Password'}
+			</button>
+		</div>
+	);
+};

--- a/auth/password/shared/src/main/_entity/password-reset-token/db-def.ts
+++ b/auth/password/shared/src/main/_entity/password-reset-token/db-def.ts
@@ -1,0 +1,30 @@
+import {tsValidateNumber, tsValidateString, tsValidateUniqueId} from '@nu-art/ts-common';
+import {Database} from '@nu-art/db-api-shared';
+import {DatabaseDef_PasswordResetToken} from './types.js';
+
+const Validator_ModifiableProps: DatabaseDef_PasswordResetToken['modifiablePropsValidator'] = {
+	accountId: tsValidateUniqueId,
+	consumedAt: tsValidateNumber(false),
+};
+
+const Validator_GeneratedProps: DatabaseDef_PasswordResetToken['generatedPropsValidator'] = {
+	token: tsValidateString(),
+	expiresAt: tsValidateNumber(),
+};
+
+export const DBDef_PasswordResetToken: Database<DatabaseDef_PasswordResetToken> = {
+	modifiablePropsValidator: Validator_ModifiableProps,
+	generatedPropsValidator: Validator_GeneratedProps,
+	generatedProps: ['token', 'expiresAt'],
+	versions: ['1.0.0'],
+	dbKey: 'password-auth--reset-token',
+	entityName: 'password-reset-token',
+	uniqueKeys: ['accountId'],
+	frontend: {
+		group: 'ts-default',
+		name: 'password-reset-token'
+	},
+	backend: {
+		name: 'password-auth--reset-token'
+	}
+};

--- a/auth/password/shared/src/main/_entity/password-reset-token/types.ts
+++ b/auth/password/shared/src/main/_entity/password-reset-token/types.ts
@@ -1,0 +1,18 @@
+import {DB_Object, DB_ProtoSeed, DB_Prototype, VersionsDeclaration} from '@nu-art/db-api-shared';
+import {DB_Account} from '@nu-art/user-account-shared';
+
+type VersionTypes_PasswordResetToken = { '1.0.0': DB_PasswordResetToken }
+type Versions = VersionsDeclaration<['1.0.0'], VersionTypes_PasswordResetToken>;
+type Dependencies = {}
+type UniqueKeys = 'accountId';
+type GeneratedProps = 'token' | 'expiresAt'
+type DBKey = 'password-auth--reset-token'
+
+export type DatabaseDef_PasswordResetToken = DB_Prototype<DB_ProtoSeed<DB_PasswordResetToken, DBKey, GeneratedProps, Versions, UniqueKeys, Dependencies>>;
+
+export type DB_PasswordResetToken = DB_Object<DBKey> & {
+	accountId: DB_Account['_id'];
+	token: string;
+	expiresAt: number;
+	consumedAt?: number;
+};

--- a/auth/password/shared/src/main/api-def.ts
+++ b/auth/password/shared/src/main/api-def.ts
@@ -11,6 +11,8 @@ export type AccountToSpice = AccountEmail & AccountPassword
 export type AccountEmailWithDevice = AccountEmail & { deviceId: string }
 export type Request_RegisterAccount = AccountEmailWithDevice & PasswordWithCheck
 export type Response_PasswordAuth = UI_Account & DB_BaseObject
+export type Request_PasswordResetRequest = AccountEmail;
+export type Request_PasswordResetExecute = { token: string } & PasswordWithCheck;
 
 export type API_PasswordAuth = {
 	registerAccount: BodyApi<Response_PasswordAuth, Request_RegisterAccount>;
@@ -18,6 +20,8 @@ export type API_PasswordAuth = {
 	changePassword: BodyApi<Response_PasswordAuth, PasswordWithCheck & { oldPassword: string }>;
 	setPassword: BodyApi<Response_PasswordAuth, PasswordWithCheck>;
 	getPasswordAssertionConfig: QueryApi<{ config: PasswordAssertionConfig | undefined }>;
+	requestReset: BodyApi<void, Request_PasswordResetRequest>;
+	executeReset: BodyApi<void, Request_PasswordResetExecute>;
 }
 
 export const ApiDef_PasswordAuth: ApiDefResolver<API_PasswordAuth> = {
@@ -26,4 +30,6 @@ export const ApiDef_PasswordAuth: ApiDefResolver<API_PasswordAuth> = {
 	changePassword: {method: HttpMethod.POST, path: '/v1/auth/password/change-password'},
 	setPassword: {method: HttpMethod.POST, path: '/v1/auth/password/set-password'},
 	getPasswordAssertionConfig: {method: HttpMethod.GET, path: '/v1/auth/password/assertion-config'},
+	requestReset: {method: HttpMethod.POST, path: '/v1/auth/password/request-reset'},
+	executeReset: {method: HttpMethod.POST, path: '/v1/auth/password/execute-reset'},
 };

--- a/auth/password/shared/src/main/index.ts
+++ b/auth/password/shared/src/main/index.ts
@@ -13,3 +13,6 @@ export * from './_entity/failed-login-attempt/consts.js';
 
 export * from './_entity/password-credentials/types.js';
 export * from './_entity/password-credentials/db-def.js';
+
+export * from './_entity/password-reset-token/types.js';
+export * from './_entity/password-reset-token/db-def.js';

--- a/ts-email/backend/.gitignore
+++ b/ts-email/backend/.gitignore
@@ -1,0 +1,2 @@
+dist/
+dist-test/

--- a/ts-email/backend/__package.json
+++ b/ts-email/backend/__package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@nu-art/ts-email-backend",
+  "version": "{{THUNDERSTORM_VERSION}}",
+  "description": "Email infrastructure backend — pluggable email sending with adapter pattern for Thunderstorm",
+  "keywords": ["TacB0sS", "infra", "nu-art", "email", "thunderstorm", "typescript"],
+  "homepage": "https://github.com/nu-art-js/thunderstorm",
+  "bugs": {"url": "https://github.com/nu-art-js/thunderstorm/issues"},
+  "repository": {"type": "git", "url": "git+ssh://git@github.com:nu-art-js/thunderstorm.git"},
+  "publishConfig": {"directory": "dist", "linkDirectory": true},
+  "license": "Apache-2.0",
+  "author": "TacB0sS",
+  "scripts": {"build": "tsc"},
+  "dependencies": {
+    "@nu-art/ts-email-shared": "?",
+    "@nu-art/ts-common": "?",
+    "@nu-art/google-services-backend": "?",
+    "@sendgrid/mail": "^8.1.0"
+  },
+  "devDependencies": {
+    "@nu-art/testalot": "?",
+    "@nu-art/storm-testalot": "?"
+  },
+  "unitConfig": {"type": "typescript-lib"},
+  "type": "module",
+  "exports": {
+    ".": {"types": "./index.d.ts", "import": "./index.js"},
+    "./*": {"types": "./*.d.ts", "import": "./*.js"}
+  }
+}

--- a/ts-email/backend/src/main/ModuleBE_Email.ts
+++ b/ts-email/backend/src/main/ModuleBE_Email.ts
@@ -1,0 +1,23 @@
+import {ImplementationMissingException, Module} from '@nu-art/ts-common';
+import {Email, EmailAdapter, EmailResult} from '@nu-art/ts-email-shared';
+
+export class ModuleBE_Email_Class
+	extends Module {
+
+	private adapter?: EmailAdapter;
+
+	public registerAdapter(adapter: EmailAdapter) {
+		this.adapter = adapter;
+		this.logInfo('Email adapter registered');
+	}
+
+	public async send(email: Email): Promise<EmailResult> {
+		if (!this.adapter)
+			throw new ImplementationMissingException('No email adapter registered. Register one via ModuleBE_Email.registerAdapter()');
+
+		this.logDebug(`Sending email to ${email.to.map(t => t.email).join(', ')} subject="${email.subject}"`);
+		return this.adapter.send(email);
+	}
+}
+
+export const ModuleBE_Email = new ModuleBE_Email_Class();

--- a/ts-email/backend/src/main/adapters/SendGridAdapter.ts
+++ b/ts-email/backend/src/main/adapters/SendGridAdapter.ts
@@ -1,0 +1,43 @@
+import {ImplementationMissingException, Module} from '@nu-art/ts-common';
+import {SecretKey} from '@nu-art/google-services-backend';
+import {Email, EmailAdapter, EmailResult} from '@nu-art/ts-email-shared';
+import sgMail from '@sendgrid/mail';
+import {ModuleBE_Email} from '../ModuleBE_Email.js';
+
+const SecretKey_SendGridApiKey = new SecretKey<string>('sendgrid-api-key');
+
+export class SendGridAdapter_Class
+	extends Module
+	implements EmailAdapter {
+
+	async init() {
+		await super.init();
+		const apiKey = await SecretKey_SendGridApiKey.get();
+		if (!apiKey)
+			throw new ImplementationMissingException('SendGrid API key not found in secrets');
+
+		sgMail.setApiKey(apiKey);
+		ModuleBE_Email.registerAdapter(this);
+	}
+
+	async send(email: Email): Promise<EmailResult> {
+		try {
+			const [response] = await sgMail.send({
+				from: email.from,
+				to: email.to,
+				subject: email.subject,
+				html: email.html,
+				text: email.text,
+			});
+			return {
+				success: response.statusCode >= 200 && response.statusCode < 300,
+				messageId: response.headers['x-message-id'] as string | undefined,
+			};
+		} catch (e: any) {
+			this.logError('SendGrid send failed', e);
+			return {success: false, error: e.message};
+		}
+	}
+}
+
+export const SendGridAdapter = new SendGridAdapter_Class();

--- a/ts-email/backend/src/main/index.ts
+++ b/ts-email/backend/src/main/index.ts
@@ -1,0 +1,3 @@
+export * from './ModuleBE_Email.js';
+export * from './adapters/SendGridAdapter.js';
+export * from './module-pack.js';

--- a/ts-email/backend/src/main/module-pack.ts
+++ b/ts-email/backend/src/main/module-pack.ts
@@ -1,0 +1,8 @@
+import {Module} from '@nu-art/ts-common';
+import {ModuleBE_Email} from './ModuleBE_Email.js';
+import {SendGridAdapter} from './adapters/SendGridAdapter.js';
+
+export const ModulePackBE_Email: Module[] = [
+	ModuleBE_Email,
+	SendGridAdapter,
+];

--- a/ts-email/shared/.gitignore
+++ b/ts-email/shared/.gitignore
@@ -1,0 +1,2 @@
+dist/
+dist-test/

--- a/ts-email/shared/__package.json
+++ b/ts-email/shared/__package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nu-art/ts-email-shared",
+  "version": "{{THUNDERSTORM_VERSION}}",
+  "description": "Email infrastructure shared types — adapter interface, email types for Thunderstorm",
+  "keywords": ["TacB0sS", "infra", "nu-art", "email", "thunderstorm", "typescript"],
+  "homepage": "https://github.com/nu-art-js/thunderstorm",
+  "bugs": {"url": "https://github.com/nu-art-js/thunderstorm/issues"},
+  "repository": {"type": "git", "url": "git+ssh://git@github.com:nu-art-js/thunderstorm.git"},
+  "publishConfig": {"directory": "dist", "linkDirectory": true},
+  "license": "Apache-2.0",
+  "author": "TacB0sS",
+  "scripts": {"build": "tsc"},
+  "dependencies": {
+    "@nu-art/ts-common": "?"
+  },
+  "devDependencies": {},
+  "unitConfig": {"type": "typescript-lib"},
+  "type": "module",
+  "exports": {
+    ".": {"types": "./index.d.ts", "import": "./index.js"},
+    "./*": {"types": "./*.d.ts", "import": "./*.js"}
+  }
+}

--- a/ts-email/shared/src/main/index.ts
+++ b/ts-email/shared/src/main/index.ts
@@ -1,0 +1,1 @@
+export * from './types.js';

--- a/ts-email/shared/src/main/types.ts
+++ b/ts-email/shared/src/main/types.ts
@@ -1,0 +1,22 @@
+export type EmailAddress = {
+	email: string;
+	name?: string;
+};
+
+export type Email = {
+	from: EmailAddress;
+	to: EmailAddress[];
+	subject: string;
+	html: string;
+	text?: string;
+};
+
+export type EmailResult = {
+	success: boolean;
+	messageId?: string;
+	error?: string;
+};
+
+export type EmailAdapter = {
+	send(email: Email): Promise<EmailResult>;
+};


### PR DESCRIPTION
## Summary
- New `ts-email` library (shared types + backend) with pluggable `EmailAdapter` pattern and SendGrid implementation
- `DB_PasswordResetToken` entity with 24h configurable TTL, single-use tokens, and rate limiting (3 requests/hour/account)
- `requestReset` and `executeReset` API endpoints on `ModuleBE_PasswordAuth` — silent failure for unknown emails, session invalidation on success
- `Component_ForgotPassword` and `Component_ResetPassword` frontend components

## Companion PRs
- news-scraper: (pending — submodule pointer update)

## Test plan
- [ ] ts-email module sends via mock adapter
- [ ] Token creation, assertion, consumption, expiry
- [ ] Rate limiting enforced at 3/hour
- [ ] Silent response for non-existent emails
- [ ] All sessions invalidated after successful reset


Made with [Cursor](https://cursor.com)