### PR TITLE
feat(#502): Add generic share API to permissions infra

### DIFF
--- a/permissions/.rules/how-to-use.mdc
+++ b/permissions/.rules/how-to-use.mdc
@@ -246,6 +246,65 @@ The `bootstrap-admin` SA is registered by default. Its scope entries are dynamic
 
 ---
 
+## Sharing document access
+
+`ModuleBE_Permissions.share` adds access group IDs to a document's `__access` field. It operates within the permissions infrastructure — app-level code never touches `__access` directly.
+
+```typescript
+import {ModuleBE_Permissions} from '@nu-art/permissions-backend';
+import type {ShareAccessContext} from '@nu-art/permissions-backend';
+
+const accessContext: ShareAccessContext = {
+	readers: [groupIdA, groupIdB],
+	writers: [groupIdC],
+};
+
+await ModuleBE_Permissions.share('my-entities', entityId, accessContext);
+```
+
+### How it works
+
+1. Loads the entity directly from MongoDB (bypasses query access filtering).
+2. Checks caller access — **SA context** skips the check; **user context** requires `writers` or `owners` access to the document.
+3. Merges the access context into `__access` via MongoDB `$addToSet` — atomic and idempotent.
+
+The pre-write interceptor that strips `__access` from app-level writes is **never weakened**. The share API writes through a privileged path that the permissions infrastructure controls.
+
+### SA context (infra-level sharing)
+
+For automated flows (e.g. post-validation handoff in file-upload), run the share call inside `runAsServiceAccount`:
+
+```typescript
+await ModuleBE_Permissions.runAsServiceAccount(myServiceAccountId, async () => {
+	await ModuleBE_Permissions.share('assets', assetId, {
+		readers: targetEntityAccessGroups,
+	});
+});
+```
+
+The SA does not need to be in the document's `__access` to share it — SA context bypasses the caller access check.
+
+### User context
+
+A user calling `share` must have **write access** to the document (be in `__access.writers` or `__access.owners`). Users without write access receive a 403 error.
+
+### ShareAccessContext
+
+`ShareAccessContext` is `Partial<DocumentAccessInner>` — you specify only the access keys you want to add to:
+
+```typescript
+type ShareAccessContext = Partial<{
+	readers: UniqueId[];
+	writers: UniqueId[];
+	deleters: UniqueId[];
+	owners: UniqueId[];
+}>;
+```
+
+Each key's array is merged into the document's existing `__access[key]` via `$addToSet` (no duplicates, idempotent).
+
+---
+
 ## When integrating permissions into an app
 
 ### Backend

--- a/permissions/backend/src/main/document-access-api.ts
+++ b/permissions/backend/src/main/document-access-api.ts
@@ -20,6 +20,11 @@ function assertOwnership(access: Partial<DocumentAccessInner> | undefined) {
 		throw HttpCodes._4XX.FORBIDDEN('Only document owners can manage access');
 }
 
+/**
+ * @deprecated Use {@link ModuleBE_Permissions.share} instead — it bypasses the pre-write interceptor
+ * via a privileged raw collection path and supports SA context. This function writes through
+ * `dbModule.set.item` which triggers the interceptor that strips `__access`.
+ */
 export async function shareDocument<Database extends DB_Prototype>(
 	dbModule: ModuleBE_BaseDB<Database>,
 	documentId: Database['uniqueParam'],
@@ -50,6 +55,10 @@ export async function shareDocument<Database extends DB_Prototype>(
 	return dbModule.set.item(mutable);
 }
 
+/**
+ * @deprecated The counterpart to the deprecated `shareDocument`. Both write through `dbModule.set.item`
+ * which triggers the pre-write interceptor that strips `__access`, making the update a no-op.
+ */
 export async function unshareDocument<Database extends DB_Prototype>(
 	dbModule: ModuleBE_BaseDB<Database>,
 	documentId: Database['uniqueParam'],

--- a/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
+++ b/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
@@ -22,11 +22,14 @@ import {ModuleBE_PermissionScopeDB} from '../_entity/permission-scope/ModuleBE_P
 import {ModuleBE_UserPermissionsDB} from '../_entity/user-permissions/ModuleBE_UserPermissionsDB.js';
 import type {OnAccessGroupChanged} from '../_entity/access-group/ModuleBE_AccessGroupDB.js';
 import {ModuleBE_AccessGroupDB} from '../_entity/access-group/ModuleBE_AccessGroupDB.js';
-import {FirebaseRef, ModuleBE_Firebase} from '@nu-art/firebase-backend';
+import {FirebaseRef, ModuleBE_Firebase, MongoCollection} from '@nu-art/firebase-backend';
 import {MemKey_ServiceAccountId, MemKey_UserAccessIds, MemKey_UserScopePermissions} from '../consts.js';
 import {type AccessContextResolver, wireDocumentAccess} from '../document-access-enforcement.js';
 import {ModuleBE_AccountDB, OnAccountDeleted, OnUserLogin} from '@nu-art/user-account-backend';
 import {DB_Account} from '@nu-art/user-account-shared';
+import {HttpCodes} from '@nu-art/api-types';
+
+export type ShareAccessContext = Partial<DocumentAccessInner>;
 
 
 // --- Dispatcher for additional group memberships on registration/login ---
@@ -125,6 +128,79 @@ class ModuleBE_Permissions_Class
 		this.accessResolvers.set(dbModule.dbDef.dbKey, resolver);
 		if (scopeKeys)
 			this.moduleScopeKeys.set(dbModule.dbDef.dbKey, scopeKeys);
+	}
+
+	// --- Share API ---
+
+	async share(dbKey: string, entityId: UniqueId, accessContext: ShareAccessContext): Promise<void> {
+		const dbModule = this.resolveDbModule(dbKey);
+		const mongoCol = this.assertMongoCollection(dbModule);
+
+		const entity = await this.loadEntityUnmanipulated(mongoCol, entityId, dbKey);
+		this.assertShareAccess(entity);
+
+		const addToSet = this.buildAddToSetUpdate(accessContext);
+		if (!addToSet)
+			return;
+
+		await mongoCol.mongoCollection.updateOne(
+			{_id: entityId} as any,
+			{$addToSet: addToSet}
+		);
+	}
+
+	private resolveDbModule(dbKey: string): ModuleBE_BaseDB<any> {
+		const dbModule = RuntimeBE_ModulesDB().find(m => m.dbDef.dbKey === dbKey);
+		if (!dbModule)
+			throw HttpCodes._4XX.BAD_REQUEST(`No DB module registered for dbKey '${dbKey}'`);
+
+		return dbModule;
+	}
+
+	private assertMongoCollection(dbModule: ModuleBE_BaseDB<any>): MongoCollection<any> {
+		if (!(dbModule.collection instanceof MongoCollection))
+			throw HttpCodes._5XX.INTERNAL_ERROR('Share API requires MongoDB backend');
+
+		return dbModule.collection;
+	}
+
+	private async loadEntityUnmanipulated(mongoCol: MongoCollection<any>, entityId: UniqueId, dbKey: string): Promise<Record<string, any>> {
+		const results = await mongoCol.query.unManipulatedQuery({where: {_id: entityId} as any, limit: 1});
+		if (!results.length)
+			throw HttpCodes._4XX.NOT_FOUND(`Entity not found: ${dbKey}/${entityId}`);
+
+		return results[0];
+	}
+
+	private assertShareAccess(entity: Record<string, any>): void {
+		if (MemKey_ServiceAccountId.peak())
+			return;
+
+		const scopedDict = MemKey_UserAccessIds.peak();
+		if (!scopedDict)
+			throw HttpCodes._4XX.FORBIDDEN('No access context — cannot share');
+
+		const callerIds = filterDuplicates(Object.values(scopedDict).flat());
+		const access: Partial<DocumentAccessInner> | undefined = entity.__access;
+		const hasWriteAccess = access?.writers?.some(id => callerIds.includes(id))
+			|| access?.owners?.some(id => callerIds.includes(id));
+
+		if (!hasWriteAccess)
+			throw HttpCodes._4XX.FORBIDDEN('Write access required to share a document');
+	}
+
+	private buildAddToSetUpdate(accessContext: ShareAccessContext): Record<string, { $each: UniqueId[] }> | undefined {
+		const update: Record<string, { $each: UniqueId[] }> = {};
+
+		for (const key of AllDocumentAccessKeys) {
+			const groupIds = accessContext[key];
+			if (!groupIds?.length)
+				continue;
+
+			update[`__access.${key}`] = {$each: groupIds};
+		}
+
+		return _keys(update).length > 0 ? update : undefined;
 	}
 
 	private wireDocumentAccessToAllModules() {

--- a/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
+++ b/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
@@ -132,7 +132,7 @@ class ModuleBE_Permissions_Class
 
 	// --- Share API ---
 
-	async share(dbKey: string, entityId: UniqueId, accessContext: ShareAccessContext): Promise<void> {
+	public async share(dbKey: string, entityId: UniqueId, accessContext: ShareAccessContext): Promise<void> {
 		const dbModule = this.resolveDbModule(dbKey);
 		const mongoCol = this.assertMongoCollection(dbModule);
 
@@ -143,10 +143,13 @@ class ModuleBE_Permissions_Class
 		if (!addToSet)
 			return;
 
-		await mongoCol.mongoCollection.updateOne(
+		const result = await mongoCol.mongoCollection.updateOne(
 			{_id: entityId} as any,
 			{$addToSet: addToSet}
 		);
+
+		if (result.matchedCount === 0)
+			throw HttpCodes._4XX.NOT_FOUND(`Entity disappeared during share: ${dbKey}/${entityId}`);
 	}
 
 	private resolveDbModule(dbKey: string): ModuleBE_BaseDB<any> {

--- a/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
+++ b/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
@@ -159,7 +159,7 @@ class ModuleBE_Permissions_Class
 
 	private assertMongoCollection(dbModule: ModuleBE_BaseDB<any>): MongoCollection<any> {
 		if (!(dbModule.collection instanceof MongoCollection))
-			throw HttpCodes._5XX.INTERNAL_ERROR('Share API requires MongoDB backend');
+			throw HttpCodes._5XX.INTERNAL_SERVER_ERROR('Share API requires MongoDB backend');
 
 		return dbModule.collection;
 	}

--- a/permissions/backend/src/test/share-api.test.ts
+++ b/permissions/backend/src/test/share-api.test.ts
@@ -1,0 +1,140 @@
+/*
+ * @nu-art/permissions-backend - Pure unit tests for share API
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {expect} from 'chai';
+import {MemStorage} from '@nu-art/ts-common/mem-storage';
+import type {DocumentAccessInner} from '@nu-art/permissions-shared';
+import {AllDocumentAccessKeys} from '@nu-art/permissions-shared';
+import {MemKey_ServiceAccountId, MemKey_UserAccessIds} from '../main/consts.js';
+import {ModuleBE_Permissions, type ShareAccessContext} from '../main/modules/ModuleBE_Permissions.js';
+
+const mod = ModuleBE_Permissions as any;
+
+describe('share API', () => {
+	describe('assertShareAccess', () => {
+		it('passes when running as service account', async () => {
+			await new MemStorage().init(async () => {
+				MemKey_ServiceAccountId.set('test-sa');
+				MemKey_UserAccessIds.set({_self: ['sa-group-id']});
+
+				expect(() => mod.assertShareAccess({__access: {readers: [], writers: [], deleters: [], owners: []}}))
+					.to.not.throw();
+			});
+		});
+
+		it('passes when user is in writers', async () => {
+			await new MemStorage().init(async () => {
+				MemKey_UserAccessIds.set({_self: ['user-group-id']});
+
+				expect(() => mod.assertShareAccess({
+					__access: {readers: [], writers: ['user-group-id'], deleters: [], owners: []}
+				})).to.not.throw();
+			});
+		});
+
+		it('passes when user is in owners', async () => {
+			await new MemStorage().init(async () => {
+				MemKey_UserAccessIds.set({_self: ['user-group-id']});
+
+				expect(() => mod.assertShareAccess({
+					__access: {readers: [], writers: [], deleters: [], owners: ['user-group-id']}
+				})).to.not.throw();
+			});
+		});
+
+		it('throws when user has no write or owner access', async () => {
+			await new MemStorage().init(async () => {
+				MemKey_UserAccessIds.set({_self: ['user-group-id']});
+
+				expect(() => mod.assertShareAccess({
+					__access: {readers: ['user-group-id'], writers: [], deleters: [], owners: []}
+				})).to.throw('Write access required');
+			});
+		});
+
+		it('throws when no access context is present', async () => {
+			await new MemStorage().init(async () => {
+				expect(() => mod.assertShareAccess({
+					__access: {readers: [], writers: [], deleters: [], owners: []}
+				})).to.throw('No access context');
+			});
+		});
+
+		it('passes with scoped access IDs that include write access', async () => {
+			await new MemStorage().init(async () => {
+				MemKey_UserAccessIds.set({
+					_self: ['personal-id'],
+					'feature-scope': ['feature-group-id'],
+				});
+
+				expect(() => mod.assertShareAccess({
+					__access: {readers: [], writers: ['feature-group-id'], deleters: [], owners: []}
+				})).to.not.throw();
+			});
+		});
+	});
+
+	describe('buildAddToSetUpdate', () => {
+		it('builds $addToSet for readers', () => {
+			const ctx: ShareAccessContext = {readers: ['group-a', 'group-b']};
+			const result = mod.buildAddToSetUpdate(ctx);
+
+			expect(result).to.deep.equal({
+				'__access.readers': {$each: ['group-a', 'group-b']},
+			});
+		});
+
+		it('builds $addToSet for multiple access keys', () => {
+			const ctx: ShareAccessContext = {
+				readers: ['group-a'],
+				writers: ['group-b'],
+			};
+			const result = mod.buildAddToSetUpdate(ctx);
+
+			expect(result).to.deep.equal({
+				'__access.readers': {$each: ['group-a']},
+				'__access.writers': {$each: ['group-b']},
+			});
+		});
+
+		it('builds $addToSet for all four access keys', () => {
+			const ctx: ShareAccessContext = {
+				readers: ['r1'],
+				writers: ['w1'],
+				deleters: ['d1'],
+				owners: ['o1'],
+			};
+			const result = mod.buildAddToSetUpdate(ctx);
+
+			expect(result).to.deep.equal({
+				'__access.readers': {$each: ['r1']},
+				'__access.writers': {$each: ['w1']},
+				'__access.deleters': {$each: ['d1']},
+				'__access.owners': {$each: ['o1']},
+			});
+		});
+
+		it('returns undefined for empty context', () => {
+			const result = mod.buildAddToSetUpdate({});
+			expect(result).to.be.undefined;
+		});
+
+		it('skips keys with empty arrays', () => {
+			const ctx: ShareAccessContext = {readers: [], writers: ['group-a']};
+			const result = mod.buildAddToSetUpdate(ctx);
+
+			expect(result).to.deep.equal({
+				'__access.writers': {$each: ['group-a']},
+			});
+		});
+
+		it('returns undefined when all arrays are empty', () => {
+			const ctx: ShareAccessContext = {readers: [], writers: [], deleters: [], owners: []};
+			const result = mod.buildAddToSetUpdate(ctx);
+			expect(result).to.be.undefined;
+		});
+	});
+});

--- a/permissions/backend/src/test/share-api.test.ts
+++ b/permissions/backend/src/test/share-api.test.ts
@@ -6,8 +6,6 @@
 
 import {expect} from 'chai';
 import {MemStorage} from '@nu-art/ts-common/mem-storage';
-import type {DocumentAccessInner} from '@nu-art/permissions-shared';
-import {AllDocumentAccessKeys} from '@nu-art/permissions-shared';
 import {MemKey_ServiceAccountId, MemKey_UserAccessIds} from '../main/consts.js';
 import {ModuleBE_Permissions, type ShareAccessContext} from '../main/modules/ModuleBE_Permissions.js';
 


### PR DESCRIPTION
## Summary

- Adds `ModuleBE_Permissions.share(dbKey, entityId, accessContext)` — a generic, atomic, idempotent share API that merges access group IDs into a document's `__access` field via MongoDB `$addToSet`
- Operates within the permissions trust boundary — bypasses the pre-write interceptor through a privileged raw collection path rather than weakening the interceptor
- Supports SA context (skip access check) and user context (requires writer/owner access)
- Exports `ShareAccessContext` type (`Partial<DocumentAccessInner>`)
- Updates permissions how-to-use rule with share API documentation
- Adds 12 pure unit tests for access-checking and `$addToSet` construction logic

## Known issues

- Existing `shareDocument`/`unshareDocument` functions in `document-access-api.ts` have the same interceptor bypass problem (they use `dbModule.set.item` which triggers the pre-write interceptor that strips `__access`). These are broken but out of scope for this task.

## Test plan

- [x] Pure unit tests pass (79/79 including 12 new share API tests)
- [x] Build passes (`bai -up=permissions-backend --build-tree`)
- [ ] Integration tests with real MongoDB (task #504)


Made with [Cursor](https://cursor.com)