### PR TITLE
feat(#487): Migrate password credentials from DB_Account to DB_PasswordCredentials

### DIFF
--- a/auth/password/backend/src/main/_entity/password-credentials/ModuleBE_PasswordCredentialDB.ts
+++ b/auth/password/backend/src/main/_entity/password-credentials/ModuleBE_PasswordCredentialDB.ts
@@ -1,11 +1,80 @@
 import {ModuleBE_BaseDB} from '@nu-art/db-api-backend';
-import {DatabaseDef_PasswordCredentials, DBDef_PasswordCredentials} from '@nu-art/password-auth-shared';
+import {DatabaseDef_PasswordCredentials, DBDef_PasswordCredentials, UI_PasswordCredentials} from '@nu-art/password-auth-shared';
+import {ModuleBE_AccountDB} from '@nu-art/user-account-backend';
+import {DB_Account} from '@nu-art/user-account-shared';
+
+type LegacyPasswordFields = {
+	salt?: string;
+	saltedPassword?: string;
+	_newPasswordRequired?: boolean;
+};
 
 export class ModuleBE_PasswordCredentialDB_Class
 	extends ModuleBE_BaseDB<DatabaseDef_PasswordCredentials> {
 
 	constructor() {
 		super(DBDef_PasswordCredentials);
+	}
+
+	async init() {
+		super.init();
+		await this.migrateFromAccounts();
+	}
+
+	private async migrateFromAccounts() {
+		const allAccounts = await ModuleBE_AccountDB.query.custom({where: {}});
+		const accountsWithPassword = allAccounts.filter(account => {
+			const raw = account as DB_Account & LegacyPasswordFields;
+			return raw.salt && raw.saltedPassword;
+		});
+
+		if (accountsWithPassword.length === 0) {
+			this.logDebug('No accounts with legacy password fields — migration not needed');
+			return;
+		}
+
+		this.logWarning(`Found ${accountsWithPassword.length} accounts with legacy password fields — migrating`);
+
+		const existingCredentials = await this.query.custom({where: {}});
+		const migratedAccountIds = new Set(existingCredentials.map(c => c.accountId));
+
+		const credentialsToCreate: UI_PasswordCredentials[] = [];
+		let skipped = 0;
+
+		for (const account of accountsWithPassword) {
+			if (account.type === 'service') {
+				skipped++;
+				continue;
+			}
+
+			if (migratedAccountIds.has(account._id)) {
+				skipped++;
+				continue;
+			}
+
+			const raw = account as DB_Account & LegacyPasswordFields;
+			credentialsToCreate.push({
+				accountId: account._id,
+				salt: raw.salt!,
+				saltedPassword: raw.saltedPassword!,
+				_newPasswordRequired: raw._newPasswordRequired,
+			});
+		}
+
+		if (credentialsToCreate.length > 0)
+			await this.create.all(credentialsToCreate);
+
+		const accountsToClean = accountsWithPassword.map(account => {
+			const cleaned = {...account};
+			delete (cleaned as DB_Account & LegacyPasswordFields).salt;
+			delete (cleaned as DB_Account & LegacyPasswordFields).saltedPassword;
+			delete (cleaned as DB_Account & LegacyPasswordFields)._newPasswordRequired;
+			return cleaned;
+		});
+
+		await ModuleBE_AccountDB.set.all(accountsToClean);
+
+		this.logWarning(`Migration complete: created=${credentialsToCreate.length} skipped=${skipped} cleaned=${accountsWithPassword.length}`);
 	}
 }
 

--- a/auth/password/backend/src/test/migration.test.firebase.ts
+++ b/auth/password/backend/src/test/migration.test.firebase.ts
@@ -1,0 +1,152 @@
+import {expect} from 'chai';
+import {generateHex, hashPasswordWithSalt} from '@nu-art/ts-common';
+import {stormTester} from '@nu-art/storm-testalot';
+import {DefaultStormTestConfig_PasswordAuth} from './utils/helpers.js';
+import {ModuleBE_AccountDB} from '@nu-art/user-account-backend';
+import {ModuleBE_PasswordCredentialDB} from './_main.js';
+
+const StormTestConfig = {
+	...DefaultStormTestConfig_PasswordAuth,
+};
+
+async function insertLegacyPasswordFields(accountId: string, salt: string, saltedPassword: string, newPasswordRequired?: boolean) {
+	const updateFields: Record<string, unknown> = {salt, saltedPassword};
+	if (newPasswordRequired !== undefined)
+		updateFields._newPasswordRequired = newPasswordRequired;
+
+	await (ModuleBE_AccountDB.collection as any).mongoCollection.updateOne(
+		{_id: accountId},
+		{$set: updateFields}
+	);
+}
+
+describe('Password Auth - Migration from DB_Account to DB_PasswordCredentials', () => {
+	it('migrates salt + saltedPassword from account to credentials', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'testpass');
+			const account = await ModuleBE_AccountDB.impl.create({email: 'user@example.com', type: 'user'});
+
+			await insertLegacyPasswordFields(account._id, salt, saltedPassword);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const credentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {accountId: account._id}, limit: 1});
+			expect(credentials).to.have.length(1);
+			expect(credentials[0].salt).to.equal(salt);
+			expect(credentials[0].saltedPassword).to.equal(saltedPassword);
+			expect(credentials[0].accountId).to.equal(account._id);
+		});
+	});
+
+	it('preserves _newPasswordRequired flag during migration', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'temppass');
+			const account = await ModuleBE_AccountDB.impl.create({email: 'user@example.com', type: 'user'});
+
+			await insertLegacyPasswordFields(account._id, salt, saltedPassword, true);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const credentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {accountId: account._id}, limit: 1});
+			expect(credentials).to.have.length(1);
+			expect(credentials[0]._newPasswordRequired).to.equal(true);
+		});
+	});
+
+	it('removes legacy fields from account after migration', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'testpass');
+			const account = await ModuleBE_AccountDB.impl.create({email: 'user@example.com', type: 'user'});
+
+			await insertLegacyPasswordFields(account._id, salt, saltedPassword, true);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const rawAccount = await (ModuleBE_AccountDB.collection as any).mongoCollection.findOne({_id: account._id});
+			expect(rawAccount).to.not.have.property('salt');
+			expect(rawAccount).to.not.have.property('saltedPassword');
+			expect(rawAccount).to.not.have.property('_newPasswordRequired');
+		});
+	});
+
+	it('skips service accounts — no credentials created', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'svcpass');
+			const svcAccount = await ModuleBE_AccountDB.impl.create({email: 'svc@example.com', type: 'service'});
+
+			await insertLegacyPasswordFields(svcAccount._id, salt, saltedPassword);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const credentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {accountId: svcAccount._id}, limit: 1});
+			expect(credentials).to.have.length(0);
+		});
+	});
+
+	it('is idempotent — running twice produces same result', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'testpass');
+			const account = await ModuleBE_AccountDB.impl.create({email: 'user@example.com', type: 'user'});
+
+			await insertLegacyPasswordFields(account._id, salt, saltedPassword);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const credentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {accountId: account._id}, limit: 1});
+			expect(credentials).to.have.length(1);
+		});
+	});
+
+	it('skips accounts without legacy password fields', async () => {
+		await stormTester(StormTestConfig, async () => {
+			await ModuleBE_AccountDB.impl.create({email: 'nopass@example.com', type: 'user'});
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const allCredentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {}});
+			expect(allCredentials).to.have.length(0);
+		});
+	});
+
+	it('migrates multiple accounts in one run', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const accounts = await Promise.all([
+				ModuleBE_AccountDB.impl.create({email: 'user1@example.com', type: 'user'}),
+				ModuleBE_AccountDB.impl.create({email: 'user2@example.com', type: 'user'}),
+				ModuleBE_AccountDB.impl.create({email: 'user3@example.com', type: 'user'}),
+			]);
+
+			for (const account of accounts) {
+				const salt = generateHex(32);
+				await insertLegacyPasswordFields(account._id, salt, hashPasswordWithSalt(salt, 'pass'));
+			}
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const allCredentials = await ModuleBE_PasswordCredentialDB.query.custom({where: {}});
+			expect(allCredentials).to.have.length(3);
+		});
+	});
+
+	it('cleans legacy fields from service accounts too', async () => {
+		await stormTester(StormTestConfig, async () => {
+			const salt = generateHex(32);
+			const saltedPassword = hashPasswordWithSalt(salt, 'svcpass');
+			const svcAccount = await ModuleBE_AccountDB.impl.create({email: 'svc@example.com', type: 'service'});
+
+			await insertLegacyPasswordFields(svcAccount._id, salt, saltedPassword);
+
+			await (ModuleBE_PasswordCredentialDB as any).migrateFromAccounts();
+
+			const rawAccount = await (ModuleBE_AccountDB.collection as any).mongoCollection.findOne({_id: svcAccount._id});
+			expect(rawAccount).to.not.have.property('salt');
+			expect(rawAccount).to.not.have.property('saltedPassword');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Overrides `init()` in `ModuleBE_PasswordCredentialDB` to migrate legacy password fields from `DB_Account` to `DB_PasswordCredentials`
- Migration is idempotent — runs on startup, no-ops when no legacy fields exist
- Includes 8 firebase integration tests

**Fix:** Re-targeting to `dev` (previous PR #44 was incorrectly squash-merged to `main`; that commit has been reverted from main via force-push)

Made with [Cursor](https://cursor.com)