### PR TITLE
feat(ui-test-harness): assertable audit trace API

### DIFF
--- a/ui-test-harness/ISSUES.md
+++ b/ui-test-harness/ISSUES.md
@@ -32,6 +32,14 @@ audit may be deferred until the tab is foregrounded.
 **Details**: Acceptable for Playwright (foregrounded headless). For non-test injection (T2+), consider a
 `setTimeout` fallback when `document.hidden`.
 
+### Symbol: `audit()` — trace buffer
+
+**Issue**: Trace entries accumulate across commits until `drainTrace()` — same lifecycle as failures.
+
+**Details**: Tests should drain trace after asserting; leaving it uncleared causes entries from later
+commits to stack. `getTrace()` is non-destructive for mid-flight observation (e.g. waiting for a
+specific component to appear in trace before draining failures).
+
 ## File: `src/main/*` — logging
 
 ### Symbol: framework logger in an injected artifact

--- a/ui-test-harness/README.md
+++ b/ui-test-harness/README.md
@@ -29,10 +29,10 @@ journey, so those defects surface without bespoke assertions per screen.
 | Export | Purpose |
 |---|---|
 | `installHook(onCommit)` | Install/augment the DevTools hook; forwards each committed root fiber. |
-| `RenderAudit` | The engine: `onCommit`, `registerContract(name, contract)`, `drain()`. |
+| `RenderAudit` | The engine: `onCommit`, `registerContract(name, contract)`, `drain()`, `getTrace()`, `drainTrace()`. |
 | `walkFibers`, `extractComponent`, `domNodeOf`, `Fiber`, `FiberRoot`, `FiberTag`, `isComponentFiber` | The fiber adapter surface. |
 | `runTier1(node)` | Generic layout invariants for a DOM node. |
-| `ExtractedComponent`, `AuditFailure`, `AuditFailureKind`, `Contract`, `ContractMap` | Types. |
+| `ExtractedComponent`, `AuditFailure`, `AuditFailureKind`, `AuditTraceEntry`, `AuditTraceAction`, `AuditTraceOutcome`, `Contract`, `ContractMap` | Types. |
 
 ## The IIFE artifact
 
@@ -59,4 +59,25 @@ installHook(audit.onCommit);                 // before createRoot
 audit.registerContract('LoginButton', t => t.node?.textContent ? undefined : 'empty label');
 // ... drive the app, then:
 const failures = audit.drain();
+```
+
+## Trace API (test assertions)
+
+Each audit walk emits structured trace entries (independent of logger routing — logger output may be
+dropped when no `BeLogged` client is configured). Use `getTrace()` to inspect or `drainTrace()` to
+assert and clear.
+
+| Field | Values |
+|---|---|
+| `action` | `audit-start`, `skip`, `tier1`, `contract`, `audit-complete` |
+| `outcome` | `pass`, `fail`, `info` (boundaries and skips) |
+| `name` | Component fiber name, or `undefined` for walk summary entries |
+| `detail` | Optional — skip reason, failure detail, or summary stats |
+
+```ts
+// Playwright — prove the walk ran and contracts passed
+const trace = await page.evaluate(() => window.__uiTestHarness.drainTrace());
+const contractPasses = trace.filter(e => e.action === 'contract' && e.outcome === 'pass');
+expect(contractPasses.map(e => e.name)).toContain('AuthScreen');
+expect(await page.evaluate(() => window.__uiTestHarness.drain())).toEqual([]);
 ```

--- a/ui-test-harness/src/main/RenderAudit.ts
+++ b/ui-test-harness/src/main/RenderAudit.ts
@@ -7,7 +7,7 @@
 import {Logger} from '@nu-art/logger';
 import {extractComponent, Fiber, isComponentFiber, walkFibers} from './fiber.js';
 import {runTier1} from './tier1.js';
-import {AuditFailure, Contract, ContractMap, ExtractedComponent} from './types.js';
+import {AuditFailure, AuditTraceEntry, Contract, ContractMap, ExtractedComponent} from './types.js';
 
 /**
  * The render-audit engine. Wired to the DevTools hook via `onCommit`, it walks every committed
@@ -21,6 +21,7 @@ export class RenderAudit
 	extends Logger {
 
 	private failures: AuditFailure[] = [];
+	private trace: AuditTraceEntry[] = [];
 	private readonly contracts: ContractMap = {};
 	private scheduled = false;
 	private latestRoot: Fiber | null = null;
@@ -66,7 +67,33 @@ export class RenderAudit
 	/** Inspect accumulated failures WITHOUT clearing — for observing audit progress (e.g. tests). */
 	readonly peek = (): AuditFailure[] => [...this.failures];
 
+	/** Inspect accumulated trace WITHOUT clearing — for observing audit progress (e.g. tests). */
+	readonly getTrace = (): readonly AuditTraceEntry[] => [...this.trace];
+
+	/** Drain and clear the accumulated audit trace. */
+	readonly drainTrace = (): AuditTraceEntry[] => {
+		const drained = this.trace;
+		this.trace = [];
+		return drained;
+	};
+
 	private readonly audit = (root: Fiber): void => {
+		let componentFibers = 0;
+		walkFibers(root, fiber => {
+			if (isComponentFiber(fiber))
+				componentFibers++;
+		});
+
+		const contractCount = Object.keys(this.contracts).length;
+		this.logInfo(`audit start — componentFibers=${componentFibers} contracts=${contractCount}`);
+		this.pushTrace({
+			name: undefined,
+			action: 'audit-start',
+			detail: `componentFibers=${componentFibers} contracts=${contractCount}`,
+			outcome: 'info',
+		});
+
+		let skipped = 0;
 		let audited = 0;
 		walkFibers(root, fiber => {
 			if (!isComponentFiber(fiber))
@@ -74,28 +101,66 @@ export class RenderAudit
 
 			const target = extractComponent(fiber);
 			if (target.state?.isLoading === true) {
+				skipped++;
 				this.logVerbose(`skip — component=${target.name} reason=isLoading`);
+				this.pushTrace({
+					name: target.name,
+					action: 'skip',
+					detail: 'isLoading',
+					outcome: 'info',
+				});
 				return;
 			}
 
 			audited++;
+			this.logDebug(`audit — component=${target.name}`);
 			this.evaluate(target);
 		});
 
-		this.logDebug(`audit complete — components=${audited} failures=${this.failures.length}`);
+		this.logInfo(`audit complete — audited=${audited} skipped=${skipped} failures=${this.failures.length}`);
+		this.pushTrace({
+			name: undefined,
+			action: 'audit-complete',
+			detail: `audited=${audited} skipped=${skipped} failures=${this.failures.length}`,
+			outcome: 'info',
+		});
 	};
 
 	private readonly evaluate = (target: ExtractedComponent): void => {
-		if (target.node)
-			runTier1(target.node).forEach(detail => this.pushFailure(target.name, 'tier1', detail));
+		const name = target.name;
 
-		const contract = target.name ? this.contracts[target.name] : undefined;
+		if (target.node) {
+			const tier1Failures = runTier1(target.node);
+			if (tier1Failures.length === 0) {
+				this.logVerbose(`tier1 pass — component=${name}`);
+				this.pushTrace({name, action: 'tier1', outcome: 'pass'});
+			} else {
+				tier1Failures.forEach(detail => {
+					this.logDebug(`tier1 fail — component=${name} detail=${detail}`);
+					this.pushTrace({name, action: 'tier1', detail, outcome: 'fail'});
+					this.pushFailure(name, 'tier1', detail);
+				});
+			}
+		} else
+			this.logVerbose(`tier1 skipped — component=${name} reason=no-node`);
+
+		const contract = name ? this.contracts[name] : undefined;
 		if (!contract)
 			return;
 
 		const detail = contract(target);
-		if (detail)
-			this.pushFailure(target.name, 'contract', detail);
+		if (detail) {
+			this.logDebug(`contract fail — component=${name} detail=${detail}`);
+			this.pushTrace({name, action: 'contract', detail, outcome: 'fail'});
+			this.pushFailure(name, 'contract', detail);
+		} else {
+			this.logDebug(`contract pass — component=${name}`);
+			this.pushTrace({name, action: 'contract', outcome: 'pass'});
+		}
+	};
+
+	private readonly pushTrace = (entry: AuditTraceEntry): void => {
+		this.trace.push(entry);
 	};
 
 	private readonly pushFailure = (name: string | undefined, kind: AuditFailure['kind'], detail: string): void => {

--- a/ui-test-harness/src/main/types.ts
+++ b/ui-test-harness/src/main/types.ts
@@ -38,3 +38,17 @@ export type Contract = (target: ExtractedComponent) => string | undefined;
 
 /** Component-name → contract registry. */
 export type ContractMap = Record<string, Contract>;
+
+/** What happened during an audit walk — assertable independently of logger routing. */
+export type AuditTraceAction = 'audit-start' | 'skip' | 'tier1' | 'contract' | 'audit-complete';
+
+/** Result of a trace step; `info` marks walk boundaries and skips (not pass/fail checks). */
+export type AuditTraceOutcome = 'pass' | 'fail' | 'info';
+
+/** One observable step in a render-audit walk, accumulated until `drainTrace()`. */
+export type AuditTraceEntry = {
+	name: string | undefined;
+	action: AuditTraceAction;
+	detail?: string;
+	outcome: AuditTraceOutcome;
+};

--- a/ui-test-harness/src/test/harness.test.playwright.ts
+++ b/ui-test-harness/src/test/harness.test.playwright.ts
@@ -15,6 +15,13 @@ const testPagePath = '/src/test/index.html';
 
 type AuditFailure = {name: string | undefined; kind: 'tier1' | 'contract'; detail: string};
 
+type AuditTraceEntry = {
+	name: string | undefined;
+	action: 'audit-start' | 'skip' | 'tier1' | 'contract' | 'audit-complete';
+	detail?: string;
+	outcome: 'pass' | 'fail' | 'info';
+};
+
 type ExtractedTarget = {
 	name: string | undefined;
 	node: Element | null;
@@ -28,6 +35,8 @@ declare global {
 			registerContract: (name: string, contract: (target: ExtractedTarget) => string | undefined) => void;
 			drain: () => AuditFailure[];
 			peek: () => AuditFailure[];
+			drainTrace: () => AuditTraceEntry[];
+			getTrace: () => readonly AuditTraceEntry[];
 		};
 		__harnessTest: {mount: () => void};
 		__preCommitCalled?: boolean;
@@ -77,6 +86,13 @@ test.describe('ui-test-harness — fiber audit self-test', () => {
 			'HiddenVisibilityProbe',
 		]));
 		expect(tier1Failures.find(f => f.name === 'CollapsedProbe')?.detail).toContain('collapsed');
+
+		const trace = await page.evaluate(() => window.__uiTestHarness.drainTrace());
+		expect(trace.some(e => e.action === 'audit-start')).toBe(true);
+		expect(trace.some(e => e.action === 'audit-complete')).toBe(true);
+		expect(trace.filter(e => e.action === 'contract' && e.name === 'StatefulProbe' && e.outcome === 'fail')).toHaveLength(1);
+		expect(trace.filter(e => e.action === 'contract' && e.name === 'StatelessProbe' && e.outcome === 'pass')).toHaveLength(1);
+		expect(trace.filter(e => e.action === 'tier1' && e.name === 'CollapsedProbe' && e.outcome === 'fail')).toHaveLength(1);
 	});
 
 	test('skips components whose state.isLoading is true', async ({page}) => {
@@ -98,6 +114,10 @@ test.describe('ui-test-harness — fiber audit self-test', () => {
 		expect(drainedNames).not.toContain('LoadingProbe');
 		// ... while the non-loading control IS audited (contract fired) — proving skip, not silence.
 		expect(drainedNames).toContain('StatefulProbe');
+
+		const trace = await page.evaluate(() => window.__uiTestHarness.drainTrace());
+		expect(trace.filter(e => e.action === 'skip' && e.name === 'LoadingProbe')).toHaveLength(1);
+		expect(trace.some(e => e.action === 'contract' && e.name === 'LoadingProbe')).toBe(false);
 	});
 
 	test('extracts class props from instance and function props from memoizedProps', async ({page}) => {


### PR DESCRIPTION
## Summary

- Adds **AuditTrace** API to `@nu-art/ui-test-harness` — structured, assertable trace events emitted during `RenderAudit` fiber walks
- Extends `RenderAudit` logging with trace hooks; documents usage in README/ISSUES
- Expands harness self-tests to cover trace assertions

## Test plan

- [x] `bai -t -tt=playwright -up=ui-test-harness` — **8/8 passing**
- [ ] Companion Beamz PR: [layout-checks reference + e2e wiring](https://github.com/nu-art/agent-playground/pull/TBD) (depends on this merge for submodule pointer)

## Merge order

**Merge this PR first.** Beamz PR bumps `_thunderstorm` gitlink to `1a468da9e`.


Made with [Cursor](https://cursor.com)