### PR TITLE
fix(ui-test-harness): SSOT audit types and single-pass fiber walk

### DIFF
--- a/ui-test-harness/src/main/RenderAudit.ts
+++ b/ui-test-harness/src/main/RenderAudit.ts
@@ -79,26 +79,14 @@ export class RenderAudit
 
 	private readonly audit = (root: Fiber): void => {
 		let componentFibers = 0;
-		walkFibers(root, fiber => {
-			if (isComponentFiber(fiber))
-				componentFibers++;
-		});
-
-		const contractCount = Object.keys(this.contracts).length;
-		this.logInfo(`audit start — componentFibers=${componentFibers} contracts=${contractCount}`);
-		this.pushTrace({
-			name: undefined,
-			action: 'audit-start',
-			detail: `componentFibers=${componentFibers} contracts=${contractCount}`,
-			outcome: 'info',
-		});
-
 		let skipped = 0;
-		let audited = 0;
+		const toAudit: ExtractedComponent[] = [];
+
 		walkFibers(root, fiber => {
 			if (!isComponentFiber(fiber))
 				return;
 
+			componentFibers++;
 			const target = extractComponent(fiber);
 			if (target.state?.isLoading === true) {
 				skipped++;
@@ -112,10 +100,24 @@ export class RenderAudit
 				return;
 			}
 
+			toAudit.push(target);
+		});
+
+		const contractCount = Object.keys(this.contracts).length;
+		this.logInfo(`audit start — componentFibers=${componentFibers} contracts=${contractCount}`);
+		this.pushTrace({
+			name: undefined,
+			action: 'audit-start',
+			detail: `componentFibers=${componentFibers} contracts=${contractCount}`,
+			outcome: 'info',
+		});
+
+		let audited = 0;
+		for (const target of toAudit) {
 			audited++;
 			this.logDebug(`audit — component=${target.name}`);
 			this.evaluate(target);
-		});
+		}
 
 		this.logInfo(`audit complete — audited=${audited} skipped=${skipped} failures=${this.failures.length}`);
 		this.pushTrace({

--- a/ui-test-harness/src/test/harness.test.playwright.ts
+++ b/ui-test-harness/src/test/harness.test.playwright.ts
@@ -6,6 +6,7 @@
  */
 
 import {expect, test} from '@playwright/test';
+import type {AuditFailure, AuditTraceEntry, Contract, ExtractedComponent} from '@nu-art/ui-test-harness';
 import {resolve} from 'path';
 import {fileURLToPath} from 'url';
 
@@ -13,26 +14,10 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const iifePath = resolve(__dirname, '../../dist-iife/harness.iife.js');
 const testPagePath = '/src/test/index.html';
 
-type AuditFailure = {name: string | undefined; kind: 'tier1' | 'contract'; detail: string};
-
-type AuditTraceEntry = {
-	name: string | undefined;
-	action: 'audit-start' | 'skip' | 'tier1' | 'contract' | 'audit-complete';
-	detail?: string;
-	outcome: 'pass' | 'fail' | 'info';
-};
-
-type ExtractedTarget = {
-	name: string | undefined;
-	node: Element | null;
-	props: Record<string, unknown> | undefined;
-	state: Record<string, unknown> | undefined;
-};
-
 declare global {
 	interface Window {
 		__uiTestHarness: {
-			registerContract: (name: string, contract: (target: ExtractedTarget) => string | undefined) => void;
+			registerContract: (name: string, contract: Contract) => void;
 			drain: () => AuditFailure[];
 			peek: () => AuditFailure[];
 			drainTrace: () => AuditTraceEntry[];
@@ -169,7 +154,7 @@ test.describe('ui-test-harness — fiber audit self-test', () => {
 	test('resolves domNodeOf to the correct host element per probe shape', async ({page}) => {
 		await page.evaluate(() => {
 			const harness = window.__uiTestHarness;
-			const expectTestId = (expected: string) => (t: ExtractedTarget) => {
+			const expectTestId = (expected: string) => (t: ExtractedComponent) => {
 				const testId = t.node?.getAttribute('data-testid');
 				if (testId !== expected)
 					return `node data-testid expected "${expected}", got "${testId ?? 'null'}"`;


### PR DESCRIPTION
## Summary
- Import `AuditFailure`, `AuditTraceEntry`, `Contract`, `ExtractedComponent` from package exports in Playwright self-test instead of duplicating shapes
- Collapse `RenderAudit.audit` to a single fiber walk (collect non-loading targets, then evaluate)

## Test plan
- [x] `bai -up=ui-test-harness` — pass
- [ ] Playwright self-test — requires `@vitejs/plugin-react` in consuming monorepo node_modules


Made with [Cursor](https://cursor.com)