### PR TITLE
fix(ts-common): extractSubdomain requires known base host (#571)

### DIFF
--- a/_docs/_handoff/change-history/2026-06-27_11:57-extract-subdomain-base-host-parameter.md
+++ b/_docs/_handoff/change-history/2026-06-27_11:57-extract-subdomain-base-host-parameter.md
@@ -1,0 +1,19 @@
+# 2026-06-27 11:57 — extractSubdomain requires explicit base host
+- **Author:** tacb0ss
+- **Packages touched:** @nu-art/ts-common
+- **Concepts / docs:** url-tools, multi-tenant subdomain parsing
+
+## Why
+
+`extractSubdomain(origin)` treated only the last DNS label as the registrable domain. That works for single-label roots like `localhost` (`acme.localhost` → `acme`) but breaks multi-label public suffixes such as `beamz.dev`: `beta.beamz.dev` was parsed as subdomain `beta.beamz` instead of tenant id `beta`. Any consuming project routing tenants on `*.beamz.dev` (or similar two-label roots) needs to strip a **known** base host, not infer TLD from the last label. A full Public Suffix List dependency is unnecessary for our deployments; callers already know their portal root (`localhost`, `beamz.dev`, etc.).
+
+The signature change is intentional: generic infra cannot guess registrable domain depth. Callers pass `baseHost`; the function returns everything to the left of `.${baseHost}` or `undefined` when the hostname is the base, an IPv4 literal, or does not match the suffix.
+
+## What changed
+
+- `ts-common/src/main/utils/url-tools.ts` — `extractSubdomain(origin, baseHost)`; IPv4 hostnames return `undefined`.
+- `ts-common/src/test/url-tools/extract-subdomain.test.ts` — unit tests for single/multi-label roots, nested subdomains, bare root, localhost, IPv4, mismatch, invalid URL.
+
+## For consumers
+
+Update call sites to pass the deployment base host. Beamz adds `deriveTenantBaseHost` / `extractTenantSubdomain` in `@app/organization-shared` as the product SSOT.

--- a/ts-common/src/main/utils/url-tools.ts
+++ b/ts-common/src/main/utils/url-tools.ts
@@ -1,29 +1,40 @@
+const IPV4_HOSTNAME = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
 /**
- * Extracts the subdomain from a URL origin.
+ * Extracts the subdomain prefix from a URL origin relative to a known base host.
  *
- * Parses the URL and extracts all parts of the hostname except the last part
- * (which is typically the domain and TLD). For example:
- * - `https://app.example.com` → `app`
- * - `https://api.v1.example.com` → `api.v1`
- * - `https://example.com` → `undefined`
+ * Strips `baseHost` from the origin hostname and returns the remaining left-hand
+ * labels. For example, with `baseHost` `beamz.dev`:
+ * - `https://beta.beamz.dev` → `beta`
+ * - `https://a.b.beamz.dev` → `a.b`
+ * - `https://beamz.dev` → `undefined`
  *
- * **Note**: This is a simple extraction and doesn't validate domain structure.
- * It assumes the last dot-separated part is the domain/TLD.
+ * IPv4 hostnames and origins that do not end with `.${baseHost}` return `undefined`.
  *
  * @param origin - The origin URL from which to extract the subdomain
- * @returns Subdomain string, or undefined if no subdomain exists or URL is invalid
+ * @param baseHost - Registrable base host (e.g. `beamz.dev`, `localhost`)
+ * @returns Subdomain string, or undefined if none exists or the URL is invalid
  */
-export const extractSubdomain = (origin: string): string | undefined => {
+export const extractSubdomain = (origin: string, baseHost: string): string | undefined => {
 	try {
 		const url = new URL(origin);
 		const hostname = url.hostname;
 
-		const parts = hostname.split('.');
-		if (parts.length > 1) {
-			return parts.slice(0, -1).join('.'); // Extract subdomain (everything before the last part)
-		}
+		if (IPV4_HOSTNAME.test(hostname))
+			return undefined;
 
-		return undefined; // No subdomain
+		const host = hostname.toLowerCase();
+		const base = baseHost.toLowerCase();
+
+		if (host === base)
+			return undefined;
+
+		const suffix = `.${base}`;
+		if (!host.endsWith(suffix))
+			return undefined;
+
+		const subdomain = host.slice(0, -suffix.length);
+		return subdomain.length > 0 ? subdomain : undefined;
 	} catch (error) {
 		console.error(`Invalid origin: ${origin}`, error);
 		return undefined;

--- a/ts-common/src/test/url-tools/extract-subdomain.test.ts
+++ b/ts-common/src/test/url-tools/extract-subdomain.test.ts
@@ -1,5 +1,6 @@
 import {extractSubdomain} from '../../main/utils/url-tools.js';
 import {runSingleTestCase, TestModel} from '@nu-art/testalot';
+import {expect} from 'chai';
 
 type Input = { origin: string; baseHost: string };
 type Result = string | undefined;
@@ -9,6 +10,10 @@ const test = async (input: Input): Promise<Result> => extractSubdomain(input.ori
 
 const runTestCase = (testCase: TestCase_ExtractSubdomain) => {
 	return () => runSingleTestCase(test, testCase);
+};
+
+const expectUndefined = (actual: string | undefined) => {
+	expect(actual).to.equal(undefined);
 };
 
 describe('extractSubdomain', () => {
@@ -38,35 +43,35 @@ describe('extractSubdomain', () => {
 			title: 'bare multi-label root — beamz.dev',
 			testCase: {
 				input: {origin: 'https://beamz.dev', baseHost: 'beamz.dev'},
-				result: undefined,
+				result: expectUndefined,
 			},
 		},
 		{
 			title: 'bare localhost',
 			testCase: {
 				input: {origin: 'https://localhost:8363', baseHost: 'localhost'},
-				result: undefined,
+				result: expectUndefined,
 			},
 		},
 		{
 			title: 'IPv4 host — no subdomain',
 			testCase: {
 				input: {origin: 'https://127.0.0.1:8363', baseHost: 'localhost'},
-				result: undefined,
+				result: expectUndefined,
 			},
 		},
 		{
 			title: 'hostname does not match base host',
 			testCase: {
 				input: {origin: 'https://beta.example.com', baseHost: 'beamz.dev'},
-				result: undefined,
+				result: expectUndefined,
 			},
 		},
 		{
 			title: 'invalid origin',
 			testCase: {
 				input: {origin: 'not-a-url', baseHost: 'localhost'},
-				result: undefined,
+				result: expectUndefined,
 			},
 		},
 	];

--- a/ts-common/src/test/url-tools/extract-subdomain.test.ts
+++ b/ts-common/src/test/url-tools/extract-subdomain.test.ts
@@ -12,7 +12,7 @@ const runTestCase = (testCase: TestCase_ExtractSubdomain) => {
 	return () => runSingleTestCase(test, testCase);
 };
 
-const expectUndefined = (actual: string | undefined) => {
+const expectUndefined = async (actual: string | undefined) => {
 	expect(actual).to.equal(undefined);
 };
 

--- a/ts-common/src/test/url-tools/extract-subdomain.test.ts
+++ b/ts-common/src/test/url-tools/extract-subdomain.test.ts
@@ -12,50 +12,66 @@ const runTestCase = (testCase: TestCase_ExtractSubdomain) => {
 };
 
 describe('extractSubdomain', () => {
-	const cases: TestCase_ExtractSubdomain[] = [
+	const cases: { title: string; testCase: TestCase_ExtractSubdomain }[] = [
 		{
-			description: 'single-label root — acme.localhost',
-			input: {origin: 'https://acme.localhost:8364', baseHost: 'localhost'},
-			result: 'acme',
+			title: 'single-label root — acme.localhost',
+			testCase: {
+				input: {origin: 'https://acme.localhost:8364', baseHost: 'localhost'},
+				result: 'acme',
+			},
 		},
 		{
-			description: 'multi-label root — beta.beamz.dev',
-			input: {origin: 'https://beta.beamz.dev', baseHost: 'beamz.dev'},
-			result: 'beta',
+			title: 'multi-label root — beta.beamz.dev',
+			testCase: {
+				input: {origin: 'https://beta.beamz.dev', baseHost: 'beamz.dev'},
+				result: 'beta',
+			},
 		},
 		{
-			description: 'nested subdomain — a.b.beamz.dev',
-			input: {origin: 'https://a.b.beamz.dev', baseHost: 'beamz.dev'},
-			result: 'a.b',
+			title: 'nested subdomain — a.b.beamz.dev',
+			testCase: {
+				input: {origin: 'https://a.b.beamz.dev', baseHost: 'beamz.dev'},
+				result: 'a.b',
+			},
 		},
 		{
-			description: 'bare multi-label root — beamz.dev',
-			input: {origin: 'https://beamz.dev', baseHost: 'beamz.dev'},
-			result: undefined,
+			title: 'bare multi-label root — beamz.dev',
+			testCase: {
+				input: {origin: 'https://beamz.dev', baseHost: 'beamz.dev'},
+				result: undefined,
+			},
 		},
 		{
-			description: 'bare localhost',
-			input: {origin: 'https://localhost:8363', baseHost: 'localhost'},
-			result: undefined,
+			title: 'bare localhost',
+			testCase: {
+				input: {origin: 'https://localhost:8363', baseHost: 'localhost'},
+				result: undefined,
+			},
 		},
 		{
-			description: 'IPv4 host — no subdomain',
-			input: {origin: 'https://127.0.0.1:8363', baseHost: 'localhost'},
-			result: undefined,
+			title: 'IPv4 host — no subdomain',
+			testCase: {
+				input: {origin: 'https://127.0.0.1:8363', baseHost: 'localhost'},
+				result: undefined,
+			},
 		},
 		{
-			description: 'hostname does not match base host',
-			input: {origin: 'https://beta.example.com', baseHost: 'beamz.dev'},
-			result: undefined,
+			title: 'hostname does not match base host',
+			testCase: {
+				input: {origin: 'https://beta.example.com', baseHost: 'beamz.dev'},
+				result: undefined,
+			},
 		},
 		{
-			description: 'invalid origin',
-			input: {origin: 'not-a-url', baseHost: 'localhost'},
-			result: undefined,
+			title: 'invalid origin',
+			testCase: {
+				input: {origin: 'not-a-url', baseHost: 'localhost'},
+				result: undefined,
+			},
 		},
 	];
 
-	cases.forEach(testCase => {
-		it(testCase.description, runTestCase(testCase));
+	cases.forEach(({title, testCase}) => {
+		it(title, runTestCase(testCase));
 	});
 });

--- a/ts-common/src/test/url-tools/extract-subdomain.test.ts
+++ b/ts-common/src/test/url-tools/extract-subdomain.test.ts
@@ -1,0 +1,61 @@
+import {extractSubdomain} from '../../main/utils/url-tools.js';
+import {runSingleTestCase, TestModel} from '@nu-art/testalot';
+
+type Input = { origin: string; baseHost: string };
+type Result = string | undefined;
+type TestCase_ExtractSubdomain = TestModel<Input, Result>;
+
+const test = async (input: Input): Promise<Result> => extractSubdomain(input.origin, input.baseHost);
+
+const runTestCase = (testCase: TestCase_ExtractSubdomain) => {
+	return () => runSingleTestCase(test, testCase);
+};
+
+describe('extractSubdomain', () => {
+	const cases: TestCase_ExtractSubdomain[] = [
+		{
+			description: 'single-label root — acme.localhost',
+			input: {origin: 'https://acme.localhost:8364', baseHost: 'localhost'},
+			result: 'acme',
+		},
+		{
+			description: 'multi-label root — beta.beamz.dev',
+			input: {origin: 'https://beta.beamz.dev', baseHost: 'beamz.dev'},
+			result: 'beta',
+		},
+		{
+			description: 'nested subdomain — a.b.beamz.dev',
+			input: {origin: 'https://a.b.beamz.dev', baseHost: 'beamz.dev'},
+			result: 'a.b',
+		},
+		{
+			description: 'bare multi-label root — beamz.dev',
+			input: {origin: 'https://beamz.dev', baseHost: 'beamz.dev'},
+			result: undefined,
+		},
+		{
+			description: 'bare localhost',
+			input: {origin: 'https://localhost:8363', baseHost: 'localhost'},
+			result: undefined,
+		},
+		{
+			description: 'IPv4 host — no subdomain',
+			input: {origin: 'https://127.0.0.1:8363', baseHost: 'localhost'},
+			result: undefined,
+		},
+		{
+			description: 'hostname does not match base host',
+			input: {origin: 'https://beta.example.com', baseHost: 'beamz.dev'},
+			result: undefined,
+		},
+		{
+			description: 'invalid origin',
+			input: {origin: 'not-a-url', baseHost: 'localhost'},
+			result: undefined,
+		},
+	];
+
+	cases.forEach(testCase => {
+		it(testCase.description, runTestCase(testCase));
+	});
+});


### PR DESCRIPTION
## Summary
- `extractSubdomain(origin, baseHost)` strips a caller-supplied registrable base instead of treating only the last DNS label as TLD
- IPv4 hostnames return `undefined` (fixes bogus `127.0.0.0` style prefixes)
- Unit tests cover single/multi-label roots, nested subdomains, bare root, localhost, IPv4, mismatch

## Why
Multi-label roots like `beamz.dev` broke tenant parsing (`beta.beamz.dev` → `beta.beamz`). Callers know their deployment base; generic infra should not guess suffix depth.

## Test plan
- [x] `bai -t -tt=pure -up=ts-common` — all tests pass including new `extract-subdomain.test.ts`


Made with [Cursor](https://cursor.com)