### PR TITLE
##573 refactor(password-auth): theme-param auth form SCSS + Label for messages

### DIFF
--- a/auth/password/frontend/src/main/ui/Component_Authenticate.scss
+++ b/auth/password/frontend/src/main/ui/Component_Authenticate.scss
@@ -16,57 +16,65 @@
  * limitations under the License.
  */
 
-@use '@nu-art/ts-styles' as styles;
-
 .ts-account__authenticate {
-  margin-top: 6px;
-  width: 300px;
-
-  > input {
-    margin-block: 4px;
-  }
+  margin-top: var(--space-xs);
+  width: 100%;
+  gap: var(--space-base);
 
   .ts-account__error-container {
     justify-content: center;
     align-items: center;
-    min-height: 22px;
+    min-height: var(--space-lg);
+    width: 100%;
+  }
 
-    .ts-account__error-messages {
-      margin-block: 0;
+  .ts-account__error-messages {
+    align-items: center;
+    gap: var(--space-xs);
+    width: 100%;
+
+    .ts-account__error-message {
+      color: var(--color-state-danger);
+      font-size: var(--font-size-control);
+      text-align: center;
     }
   }
 
   .ts-account__message {
     text-align: center;
-    margin-block: 8px 0;
-    color: var(--text-color-secondary, inherit);
+    margin-block: var(--space-sm) 0;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-control);
+  }
+
+  .ts-account__action-button {
+    width: 100%;
   }
 
   .ts-account__authenticate__password-rules {
-    border: 1px solid black;
-    border-radius: 10px;
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-lg);
     width: 100%;
-    padding: 10px;
+    padding: var(--space-md);
     grid-template-columns: 1fr 1fr;
-    gap: 10px;
-    margin-top: 10px;
+    gap: var(--space-md);
+    margin-top: var(--space-md);
 
     .ts-account__authenticate__password-rule {
-      gap: 10px;
+      gap: var(--space-md);
       align-items: center;
-      color: styles.red(3);
-
-      .icon--wrapper {
-        @include styles.mouse-interactive-icon(styles.red(3));
-      }
+      color: var(--color-state-danger);
+      font-size: var(--font-size-control);
 
       &.valid {
-        color: styles.green(2);
-
-        .icon--wrapper {
-          @include styles.mouse-interactive-icon(styles.green(2));
-        }
+        color: var(--color-state-success);
       }
     }
   }
+}
+
+.login-blocked {
+  justify-content: center;
+  color: var(--color-state-warn);
+  font-size: var(--font-size-control);
 }

--- a/auth/password/frontend/src/main/ui/Component_ForgotPassword/Component_ForgotPassword.tsx
+++ b/auth/password/frontend/src/main/ui/Component_ForgotPassword/Component_ForgotPassword.tsx
@@ -17,7 +17,7 @@
  */
 
 import {Button, ComponentSync, LL_H_C, LL_V_C, TS_PropRenderer} from '@nu-art/thunder-widgets';
-import {TS_Input} from '@nu-art/thunder-widgets/v3';
+import {Label, TS_Input} from '@nu-art/thunder-widgets/v3';
 import {ModuleFE_PasswordAuth} from '../../ModuleFE_PasswordAuth.js';
 import './Component_ForgotPassword.scss';
 
@@ -71,7 +71,7 @@ export class Component_ForgotPassword
 	render() {
 		if (this.state.submitted)
 			return <LL_V_C className="ts-account__authenticate">
-				<p className={'ts-account__message'}>If an account exists for {this.state.email}, we sent a password reset link.</p>
+				<Label className={'ts-account__message'}>If an account exists for {this.state.email}, we sent a password reset link.</Label>
 			</LL_V_C>;
 
 		return <LL_V_C className="ts-account__authenticate">
@@ -101,8 +101,8 @@ export class Component_ForgotPassword
 		if (!this.state.errorMessages?.length)
 			return '';
 
-		return <ul className={'ts-account__error-messages'}>
-			{this.state.errorMessages.map((message, i) => <li key={i}>{message}</li>)}
-		</ul>;
+		return <LL_V_C className={'ts-account__error-messages'}>
+			{this.state.errorMessages.map((message, i) => <Label key={i} className={'ts-account__error-message'}>{message}</Label>)}
+		</LL_V_C>;
 	};
 }

--- a/auth/password/frontend/src/main/ui/Component_Login/Component_Login.tsx
+++ b/auth/password/frontend/src/main/ui/Component_Login/Component_Login.tsx
@@ -2,6 +2,7 @@ import {_keys, exists, formatTimestamp} from '@nu-art/ts-common';
 import {AccountPassword, API_PasswordAuth, ErrorType_LoginBlocked} from '@nu-art/password-auth-shared';
 import './Component_Login.scss';
 import {Button, ComponentSync, LL_H_C, LL_V_C, TS_PropRenderer} from '@nu-art/thunder-widgets';
+import {Label} from '@nu-art/thunder-widgets/v3';
 import {ModuleFE_PasswordAuth} from '../../ModuleFE_PasswordAuth.js';
 import {StorageKey_DeviceId} from '@nu-art/user-account-frontend';
 import {Component_LoginBlocked} from '../Component_LoginBlocked/Component_LoginBlocked.js';
@@ -134,11 +135,11 @@ export class Component_Login
 		if (!this.state.errorMessages?.length)
 			return '';
 
-		return <ul className={'ts-account__error-messages'}>
+		return <LL_V_C className={'ts-account__error-messages'}>
 			{this.state.errorMessages.map((message, i) => {
-				return <li key={i}>{message}</li>;
+				return <Label key={i} className={'ts-account__error-message'}>{message}</Label>;
 			})}
-		</ul>;
+		</LL_V_C>;
 	};
 
 	private renderAccountBlockedTimer = () => {

--- a/auth/password/frontend/src/main/ui/Component_Register.tsx
+++ b/auth/password/frontend/src/main/ui/Component_Register.tsx
@@ -17,7 +17,7 @@ import {AccountEmail} from '@nu-art/user-account-shared';
 import {ModuleFE_PasswordAuth} from '../ModuleFE_PasswordAuth.js';
 import {StorageKey_DeviceId} from '@nu-art/user-account-frontend';
 import {TS_Icons} from '@nu-art/ts-styles';
-import {TS_Input} from '@nu-art/thunder-widgets/v3';
+import {Label, TS_Input} from '@nu-art/thunder-widgets/v3';
 import {_className} from '@nu-art/thunder-core';
 
 type State<T> = {
@@ -177,7 +177,9 @@ export class Component_Register
 					</TS_PropRenderer.Vertical>;
 				}
 			)}
-			{this.renderErrorMessages()}
+			<LL_H_C className={'ts-account__error-container'}>
+				{this.renderErrorMessages()}
+			</LL_H_C>
 			<Button
 				variant={'primary'}
 				onClick={this.registerClicked}
@@ -192,11 +194,11 @@ export class Component_Register
 		if (!this.state.errorMessages?.length)
 			return '';
 
-		return <ul className={'ts-account__error-messages'}>
+		return <LL_V_C className={'ts-account__error-messages'}>
 			{this.state.errorMessages.map((message, i) => {
-				return <li key={i}>{message}</li>;
+				return <Label key={i} className={'ts-account__error-message'}>{message}</Label>;
 			})}
-		</ul>;
+		</LL_V_C>;
 	};
 
 	private renderPasswordRules = () => {

--- a/auth/password/frontend/src/main/ui/Component_ResetPassword/Component_ResetPassword.tsx
+++ b/auth/password/frontend/src/main/ui/Component_ResetPassword/Component_ResetPassword.tsx
@@ -18,7 +18,7 @@
 
 import {_keys} from '@nu-art/ts-common';
 import {Button, ComponentSync, LL_H_C, LL_V_C, TS_PropRenderer} from '@nu-art/thunder-widgets';
-import {TS_Input} from '@nu-art/thunder-widgets/v3';
+import {Label, TS_Input} from '@nu-art/thunder-widgets/v3';
 import {ModuleFE_PasswordAuth} from '../../ModuleFE_PasswordAuth.js';
 import './Component_ResetPassword.scss';
 
@@ -109,7 +109,7 @@ export class Component_ResetPassword
 	render() {
 		if (this.state.success)
 			return <LL_V_C className="ts-account__authenticate">
-				<p className={'ts-account__message'}>Your password has been reset successfully. You can now log in.</p>
+				<Label className={'ts-account__message'}>Your password has been reset successfully. You can now log in.</Label>
 			</LL_V_C>;
 
 		const data = this.state.data;
@@ -143,8 +143,8 @@ export class Component_ResetPassword
 		if (!this.state.errorMessages?.length)
 			return '';
 
-		return <ul className={'ts-account__error-messages'}>
-			{this.state.errorMessages.map((message, i) => <li key={i}>{message}</li>)}
-		</ul>;
+		return <LL_V_C className={'ts-account__error-messages'}>
+			{this.state.errorMessages.map((message, i) => <Label key={i} className={'ts-account__error-message'}>{message}</Label>)}
+		</LL_V_C>;
 	};
 }


### PR DESCRIPTION
## Summary
- Tokenize `Component_Authenticate.scss` (full-width form, errors, password rules, action button, login-blocked) to semantic theme tokens.
- Login/register/forgot/reset components use `Label` (v3) for messages/errors instead of raw `p`/`ul`/`li`.

## Companion PR
- nu-art/agent-playground (beamz): feature/#573 → main (auth shell + portal roots)

## Test plan
- [x] `bai -up=password-auth-frontend|common-frontend|admin-portal|org-portal` — green from main clone
- [x] `bai -t -tt=pure -up=common-frontend` — 16 passing

Made with [Cursor](https://cursor.com)