### PR TITLE
feat(e2e-harness): shared programmatic E2E stack bootstrap

### DIFF
--- a/auth/password/frontend/src/main/index.ts
+++ b/auth/password/frontend/src/main/index.ts
@@ -1,6 +1,7 @@
 export * from './ModuleFE_PasswordAuth.js';
 export * from './module-pack.js';
 export * from './consts.js';
+export * from './ui/resolve-login-failure.js';
 export * from './ui/Component_Login/Component_Login.js';
 export * from './ui/Component_Register.js';
 export * from './ui/Component_ChangePassword/Component_ChangePassword.js';

--- a/auth/password/frontend/src/main/ui/Component_Login/Component_Login.tsx
+++ b/auth/password/frontend/src/main/ui/Component_Login/Component_Login.tsx
@@ -1,5 +1,6 @@
-import {_keys, exists, formatTimestamp} from '@nu-art/ts-common';
-import {AccountPassword, API_PasswordAuth, ErrorType_LoginBlocked} from '@nu-art/password-auth-shared';
+import {_keys, exists} from '@nu-art/ts-common';
+import {AccountPassword, API_PasswordAuth} from '@nu-art/password-auth-shared';
+import {resolveLoginFailure} from '../resolve-login-failure.js';
 import './Component_Login.scss';
 import {Button, ComponentSync, LL_H_C, LL_V_C, TS_PropRenderer} from '@nu-art/thunder-widgets';
 import {Label} from '@nu-art/thunder-widgets/v3';
@@ -75,15 +76,8 @@ export class Component_Login
 			try {
 				await ModuleFE_PasswordAuth.login({...this.state.data, deviceId: StorageKey_DeviceId.get()} as API_PasswordAuth['login']['Body']);
 				this.setState({submitting: false});
-			} catch (err: any) {
-				if (err.errorResponse.error?.type === ErrorType_LoginBlocked) {
-					const blockedUntil = err.errorResponse.error.data.blockedUntil;
-					return this.setState({
-						blockedUntil: blockedUntil,
-						errorMessages: [`Login blocked until ${formatTimestamp('DD/MM/YYYY HH:mm', blockedUntil)}`],
-					});
-				}
-				this.setState({errorMessages: ['Email or password incorrect'], submitting: false});
+			} catch (err: unknown) {
+				this.setState({...resolveLoginFailure(err), submitting: false});
 			}
 		});
 	};

--- a/auth/password/frontend/src/main/ui/resolve-login-failure.ts
+++ b/auth/password/frontend/src/main/ui/resolve-login-failure.ts
@@ -1,0 +1,52 @@
+import {formatTimestamp} from '@nu-art/ts-common';
+import {ErrorType_LoginBlocked} from '@nu-art/password-auth-shared';
+import {HttpException} from '@nu-art/http-client';
+
+export const LoginFailureMessage_Credentials = 'Email or password incorrect';
+export const LoginFailureMessage_Unavailable = 'Could not sign in — please try again';
+
+export type LoginFailureUi = {
+	errorMessages: string[];
+	blockedUntil?: number;
+};
+
+type LoginErrorBody = {
+	type?: string;
+	data?: { blockedUntil?: number };
+};
+
+type ErrorEnvelope = {
+	error?: LoginErrorBody;
+	debugMessage?: unknown;
+};
+
+const readLoginErrorBody = (err: unknown): LoginErrorBody | undefined => {
+	if (!(err instanceof HttpException))
+		return undefined;
+
+	const wrapped = err.errorResponse as ErrorEnvelope | undefined;
+	if (wrapped?.error)
+		return wrapped.error;
+
+	const debug = wrapped?.debugMessage;
+	if (debug && typeof debug === 'object' && debug !== null && 'error' in debug)
+		return (debug as ErrorEnvelope).error;
+
+	return undefined;
+};
+
+export const resolveLoginFailure = (err: unknown): LoginFailureUi => {
+	const body = readLoginErrorBody(err);
+	const blockedUntil = body?.type === ErrorType_LoginBlocked ? body.data?.blockedUntil : undefined;
+	if (typeof blockedUntil === 'number')
+		return {
+			blockedUntil,
+			errorMessages: [`Login blocked until ${formatTimestamp('DD/MM/YYYY HH:mm', blockedUntil)}`],
+		};
+
+	const status = err instanceof HttpException ? err.responseCode : undefined;
+	if (status !== undefined && (status >= 500 || status === 0))
+		return {errorMessages: [LoginFailureMessage_Unavailable]};
+
+	return {errorMessages: [LoginFailureMessage_Credentials]};
+};

--- a/auth/password/frontend/src/test/resolve-login-failure.test.ts
+++ b/auth/password/frontend/src/test/resolve-login-failure.test.ts
@@ -1,0 +1,46 @@
+import {assert} from 'chai';
+import {HttpException} from '@nu-art/http-client';
+import {ErrorType_LoginBlocked} from '@nu-art/password-auth-shared';
+import {
+	LoginFailureMessage_Credentials,
+	LoginFailureMessage_Unavailable,
+	resolveLoginFailure,
+} from '../main/ui/resolve-login-failure.js';
+
+const fakeRequest = {getUrl: () => '/v1/organization/apex-login'} as ConstructorParameters<typeof HttpException>[1];
+
+describe('resolveLoginFailure', () => {
+	it('reads BLOCKED_LOGIN from errorResponse.error', () => {
+		const blockedUntil = 1_700_000_000_000;
+		const err = new HttpException(403, fakeRequest, {
+			error: {type: ErrorType_LoginBlocked, data: {blockedUntil}},
+		});
+		const result = resolveLoginFailure(err);
+		assert.equal(result.blockedUntil, blockedUntil);
+		assert.include(result.errorMessages[0], 'Login blocked until');
+	});
+
+	it('reads BLOCKED_LOGIN when the body is nested under debugMessage', () => {
+		const blockedUntil = 1_700_000_000_000;
+		const err = new HttpException(403, fakeRequest, {});
+		err.errorResponse = {
+			debugMessage: {error: {type: ErrorType_LoginBlocked, data: {blockedUntil}}},
+		} as unknown as HttpException['errorResponse'];
+		const result = resolveLoginFailure(err);
+		assert.equal(result.blockedUntil, blockedUntil);
+	});
+
+	it('maps 5xx to a retry message', () => {
+		const err = new HttpException(500, fakeRequest, {});
+		assert.deepEqual(resolveLoginFailure(err).errorMessages, [LoginFailureMessage_Unavailable]);
+	});
+
+	it('maps other 4xx to credentials copy', () => {
+		const err = new HttpException(401, fakeRequest, {});
+		assert.deepEqual(resolveLoginFailure(err).errorMessages, [LoginFailureMessage_Credentials]);
+	});
+
+	it('maps a non-HTTP error to credentials copy', () => {
+		assert.deepEqual(resolveLoginFailure(new Error('nope')).errorMessages, [LoginFailureMessage_Credentials]);
+	});
+});

--- a/e2e-harness/.gitignore
+++ b/e2e-harness/.gitignore
@@ -1,0 +1,17 @@
+# Global
+**/.DS_Store
+
+# Node
+node_modules
+
+# Thunderstorm
+dist
+dist-test
+docs
+build
+package.json
+package-lock.json
+config.ts
+src/main/tsconfig.json
+src/test/tsconfig.json
+.eslintrc.js

--- a/e2e-harness/LICENSE
+++ b/e2e-harness/LICENSE
@@ -1,0 +1,3 @@
+Apache License
+Version 2.0, January 2004
+Full license here: http://www.apache.org/licenses/LICENSE-2.0

--- a/e2e-harness/README.md
+++ b/e2e-harness/README.md
@@ -1,0 +1,42 @@
+# @nu-art/e2e-harness
+
+Abstract programmatic bootstrap for product E2E stacks. Products implement `startup.startStack` (mongo, Firebase emulators, Storm backend); this package only ensures, health-polls, and tears down.
+
+## Purpose
+
+`E2EHarness.ensure` makes a configured health URL reachable. It can reuse an already-running stack or call the product's `startStack` hook, then poll until GET succeeds. Tests must run via a single `bai -t -nb` — no manual pre-launch.
+
+Product journeys (password-auth HTTP, Playwright portals) live in `@app/e2e` (or similar), not here.
+
+## Usage
+
+```ts
+import {E2EHarness, type E2EHarnessConfig} from '@nu-art/e2e-harness';
+
+const config: E2EHarnessConfig = {
+	backendPackage: '@app/backend',
+	healthUrl: 'https://localhost:8102/',
+	reuseExistingStack: false,
+	startup: {
+		applyEnv: () => {
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED ??= '0';
+			process.env.BACKEND_PORT ??= '8102';
+		},
+		startStack: startProductE2EStack,
+	},
+};
+
+const handle = await E2EHarness.ensure(config);
+await handle.teardown();
+```
+
+Child processes spawned from BAI mocha must **delete `NODE_OPTIONS`**. BAI registers `ts-node/esm` and that crashes `firebase` CLI and `node dist/index.js`.
+
+## Public exports
+
+| Symbol | Role |
+|--------|------|
+| `E2EHarness` | `ensure`, `teardownActive` |
+| `E2EHarnessConfig` / `E2EHarnessHandle` / `E2EHarnessOwnedResources` / `E2EHarnessStartupHooks` | Config and session types |
+| `waitForHealthUrl`, `createFetchHealthProbe`, `HealthProbe` | Health polling |
+| `DEFAULT_READY_TIMEOUT_MS` (120s), `DEFAULT_POLL_INTERVAL_MS` (500ms) | Timing defaults |

--- a/e2e-harness/__package.json
+++ b/e2e-harness/__package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@nu-art/e2e-harness",
+	"version": "{{THUNDERSTORM_VERSION}}",
+	"description": "Abstract programmatic bootstrap for product E2E stacks (backend + emulators + health gates)",
+	"type": "module",
+	"keywords": [
+		"e2e",
+		"harness",
+		"test",
+		"thunderstorm",
+		"nu-art"
+	],
+	"homepage": "https://github.com/nu-art-js/thunderstorm",
+	"bugs": {
+		"url": "https://github.com/nu-art-js/thunderstorm/issues?q=is%3Aissue+label%3Ae2e-harness"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+ssh://git@github.com:nu-art-js/thunderstorm.git",
+		"directory": "_thunderstorm/e2e-harness"
+	},
+	"publishConfig": {
+		"directory": "dist",
+		"linkDirectory": true
+	},
+	"license": "Apache-2.0",
+	"author": "TacB0sS",
+	"scripts": {
+		"build": "tsc"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@nu-art/testalot": "?"
+	},
+	"unitConfig": {
+		"type": "typescript-lib"
+	},
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.js"
+		}
+	}
+}

--- a/e2e-harness/src/main/E2EHarness.ts
+++ b/e2e-harness/src/main/E2EHarness.ts
@@ -1,0 +1,93 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {
+	createFetchHealthProbe,
+	DEFAULT_POLL_INTERVAL_MS,
+	DEFAULT_READY_TIMEOUT_MS,
+	type HealthProbe,
+	waitForHealthUrl,
+} from './health-check.js';
+import type {E2EHarnessConfig, E2EHarnessHandle, E2EHarnessOwnedResources} from './types.js';
+
+class E2EHarnessSession implements E2EHarnessHandle {
+	constructor(
+		readonly config: Readonly<E2EHarnessConfig>,
+		readonly reusedExisting: boolean,
+		private readonly ownedTeardown?: () => Promise<void>,
+	) {}
+
+	async teardown(): Promise<void> {
+		if (this.ownedTeardown)
+			await this.ownedTeardown();
+		E2EHarness.clearActive(this);
+	}
+}
+
+/** Programmatic lifecycle for full product stacks (Storm backend + emulators + health gates). */
+export class E2EHarness {
+	private static active: E2EHarnessSession | undefined;
+
+	/**
+	 * Ensures the configured stack is reachable.
+	 * Reuses an already-running stack when the health URL responds.
+	 */
+	static async ensure(
+		config: E2EHarnessConfig,
+		probe: HealthProbe = createFetchHealthProbe(),
+	): Promise<E2EHarnessHandle> {
+		if (E2EHarness.active && await probe(config.healthUrl))
+			return E2EHarness.active;
+
+		config.startup?.applyEnv?.();
+
+		const reuseExisting = config.reuseExistingStack ?? true;
+		if (reuseExisting && await probe(config.healthUrl)) {
+			const handle = new E2EHarnessSession(config, true);
+			E2EHarness.active = handle;
+			return handle;
+		}
+
+		if (!config.startup?.startStack)
+			throw bootstrapNotImplementedError(config);
+
+		const owned = await config.startup.startStack();
+		await waitForHealthUrl(
+			config.healthUrl,
+			probe,
+			config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+			config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+		);
+		const handle = new E2EHarnessSession(config, false, resolveOwnedTeardown(owned));
+		E2EHarness.active = handle;
+		return handle;
+	}
+
+	/** Tear down the active harness session, if any. */
+	static async teardownActive(): Promise<void> {
+		await E2EHarness.active?.teardown();
+	}
+
+	static clearActive(session: E2EHarnessSession): void {
+		if (E2EHarness.active === session)
+			E2EHarness.active = undefined;
+	}
+}
+
+function resolveOwnedTeardown(owned: E2EHarnessOwnedResources | void): (() => Promise<void>) | undefined {
+	if (!owned?.teardown)
+		return undefined;
+	return owned.teardown.bind(owned);
+}
+
+function bootstrapNotImplementedError(config: E2EHarnessConfig): Error {
+	return new Error(
+		`E2E harness: programmatic bootstrap for ${config.backendPackage} is not implemented yet. ` +
+		`Implement startup.startStack in the consumer config. ` +
+		`Health URL: ${config.healthUrl}. ` +
+		'Tests must run via a single `bai -t -nb` command — no manual pre-launch.',
+	);
+}

--- a/e2e-harness/src/main/health-check.ts
+++ b/e2e-harness/src/main/health-check.ts
@@ -1,0 +1,42 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+export const DEFAULT_READY_TIMEOUT_MS = 120_000;
+export const DEFAULT_POLL_INTERVAL_MS = 500;
+
+/** Probe whether a health URL responds to GET. Injectable for unit tests. */
+export type HealthProbe = (url: string) => Promise<boolean>;
+
+export function createFetchHealthProbe(options?: {relaxTls?: boolean}): HealthProbe {
+	const relaxTls = options?.relaxTls ?? true;
+	return async (url: string) => {
+		if (relaxTls)
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED ??= '0';
+		const response = await fetch(url, {method: 'GET'}).catch(() => undefined);
+		return !!response;
+	};
+}
+
+export async function waitForHealthUrl(
+	url: string,
+	probe: HealthProbe,
+	timeoutMs: number = DEFAULT_READY_TIMEOUT_MS,
+	pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await probe(url))
+			return;
+		await sleep(pollIntervalMs);
+	}
+	throw new Error(
+		`E2E harness: health URL did not become reachable at ${url} within ${timeoutMs}ms.`,
+	);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/e2e-harness/src/main/index.ts
+++ b/e2e-harness/src/main/index.ts
@@ -1,0 +1,20 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+export {E2EHarness} from './E2EHarness.js';
+export {
+	createFetchHealthProbe,
+	DEFAULT_POLL_INTERVAL_MS,
+	DEFAULT_READY_TIMEOUT_MS,
+	waitForHealthUrl,
+	type HealthProbe,
+} from './health-check.js';
+export type {
+	E2EHarnessConfig,
+	E2EHarnessHandle,
+	E2EHarnessOwnedResources,
+	E2EHarnessStartupHooks,
+} from './types.js';

--- a/e2e-harness/src/main/types.ts
+++ b/e2e-harness/src/main/types.ts
@@ -1,0 +1,42 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+/** Resources owned by a harness-owned stack bootstrap (for teardown). */
+export type E2EHarnessOwnedResources = {
+	teardown: () => Promise<void>;
+};
+
+/** Consumer-provided hooks for env, ports, and programmatic stack start. */
+export type E2EHarnessStartupHooks = {
+	/** Apply env vars before bootstrap (ports, emulator hosts, TLS flags). */
+	applyEnv?: () => void;
+	/**
+	 * Start mongo/firebase/backend when the health URL is unreachable.
+	 * Return owned resources when this process spawned the stack.
+	 */
+	startStack?: () => Promise<E2EHarnessOwnedResources | void>;
+};
+
+/** Config injected by the product E2E consumer (e.g. `@app/e2e`). */
+export type E2EHarnessConfig = {
+	/** npm package key for the backend entry (documentation + future BAI integration). */
+	backendPackage: string;
+	/** GET URL polled until reachable (typically backend root over HTTPS). */
+	healthUrl: string;
+	readyTimeoutMs?: number;
+	pollIntervalMs?: number;
+	/** When false, always runs startup.startStack even if healthUrl already responds. Default true. */
+	reuseExistingStack?: boolean;
+	startup?: E2EHarnessStartupHooks;
+};
+
+/** Active harness session returned by {@link E2EHarness.ensure}. */
+export type E2EHarnessHandle = {
+	readonly config: Readonly<E2EHarnessConfig>;
+	/** True when an already-running stack was reused (e.g. human dev session). */
+	readonly reusedExisting: boolean;
+	teardown(): Promise<void>;
+};

--- a/e2e-harness/src/test/E2EHarness.test.ts
+++ b/e2e-harness/src/test/E2EHarness.test.ts
@@ -1,0 +1,89 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {expect} from 'chai';
+import {E2EHarness} from '../main/E2EHarness.js';
+import type {E2EHarnessConfig} from '../main/types.js';
+
+describe('E2EHarness', () => {
+	const baseConfig: E2EHarnessConfig = {
+		backendPackage: '@app/backend',
+		healthUrl: 'https://127.0.0.1:8102/',
+	};
+
+	afterEach(async () => {
+		await E2EHarness.teardownActive();
+	});
+
+	it('reuses an already reachable stack without calling startStack', async () => {
+		let startCalls = 0;
+		const handle = await E2EHarness.ensure({
+			...baseConfig,
+			startup: {
+				startStack: async () => {
+					startCalls++;
+				},
+			},
+		}, async () => true);
+
+		expect(handle.reusedExisting).to.be.true;
+		expect(startCalls).to.equal(0);
+	});
+
+	it('throws when stack is unreachable and startStack is missing', async () => {
+		try {
+			await E2EHarness.ensure(baseConfig, async () => false);
+			expect.fail('expected bootstrap error');
+		} catch (error) {
+			expect((error as Error).message).to.match(/not implemented yet/);
+			expect((error as Error).message).to.match(/no manual pre-launch/);
+		}
+	});
+
+	it('starts stack and waits for health when bootstrap hook is provided', async () => {
+		let started = false;
+		let probeCalls = 0;
+		const handle = await E2EHarness.ensure({
+			...baseConfig,
+			readyTimeoutMs: 1_000,
+			pollIntervalMs: 5,
+			startup: {
+				startStack: async () => {
+					started = true;
+				},
+			},
+		}, async () => {
+			probeCalls++;
+			return started;
+		});
+
+		expect(handle.reusedExisting).to.be.false;
+		expect(started).to.be.true;
+		expect(probeCalls).to.be.greaterThan(0);
+	});
+
+	it('teardown invokes owned resources from startStack', async () => {
+		let tornDown = false;
+		let stackStarted = false;
+		await E2EHarness.ensure({
+			...baseConfig,
+			startup: {
+				startStack: async () => {
+					stackStarted = true;
+					return {
+						teardown: async () => {
+							tornDown = true;
+						},
+					};
+				},
+			},
+		}, async () => stackStarted);
+
+		expect(stackStarted).to.be.true;
+		await E2EHarness.teardownActive();
+		expect(tornDown).to.be.true;
+	});
+});

--- a/e2e-harness/src/test/health-check.test.ts
+++ b/e2e-harness/src/test/health-check.test.ts
@@ -1,0 +1,57 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {expect} from 'chai';
+import {DEFAULT_POLL_INTERVAL_MS, DEFAULT_READY_TIMEOUT_MS, waitForHealthUrl} from '../main/health-check.js';
+
+describe('E2E harness health-check', () => {
+	it('waitForHealthUrl resolves when probe succeeds immediately', async () => {
+		let calls = 0;
+		await waitForHealthUrl(
+			'https://example.test/',
+			async () => {
+				calls++;
+				return true;
+			},
+			1_000,
+			10,
+		);
+		expect(calls).to.equal(1);
+	});
+
+	it('waitForHealthUrl polls until probe succeeds', async () => {
+		let calls = 0;
+		await waitForHealthUrl(
+			'https://example.test/',
+			async () => {
+				calls++;
+				return calls >= 3;
+			},
+			1_000,
+			5,
+		);
+		expect(calls).to.equal(3);
+	});
+
+	it('waitForHealthUrl throws after timeout', async () => {
+		try {
+			await waitForHealthUrl(
+				'https://127.0.0.1:59999/',
+				async () => false,
+				50,
+				10,
+			);
+			expect.fail('expected timeout error');
+		} catch (error) {
+			expect((error as Error).message).to.match(/did not become reachable/);
+		}
+	});
+
+	it('exports stable default timing constants', () => {
+		expect(DEFAULT_READY_TIMEOUT_MS).to.equal(120_000);
+		expect(DEFAULT_POLL_INTERVAL_MS).to.equal(500);
+	});
+});

--- a/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
+++ b/permissions/backend/src/main/modules/ModuleBE_Permissions.ts
@@ -676,16 +676,27 @@ class ModuleBE_Permissions_Class
 
 	private deduplicateScopeEntries(scopeEntities: DB_PermissionScope[]): string[] {
 		const scopeMaxIdx: Record<string, { value: string; idx: number }> = {};
+		const unregistered: string[] = [];
 		for (const entity of scopeEntities) {
 			const scopeValues = getPermissionScopeValues(entity.key);
-			const valueIdx = scopeValues ? scopeValues.indexOf(entity.value) : -1;
+			// Dynamic per-instance scopes (e.g. organization/{id}) are not in the
+			// global registry — collapsing them by idx=-1 keeps the first value
+			// (often can-invite) and drops admin. Keep every distinct key:value.
+			if (!scopeValues) {
+				unregistered.push(`${entity.key}:${entity.value}`);
+				continue;
+			}
 
+			const valueIdx = scopeValues.indexOf(entity.value);
 			const current = scopeMaxIdx[entity.key];
 			if (!current || valueIdx > current.idx)
 				scopeMaxIdx[entity.key] = {value: entity.value, idx: valueIdx};
 		}
 
-		return _keys(scopeMaxIdx).map(k => `${k}:${scopeMaxIdx[k].value}`);
+		return [
+			..._keys(scopeMaxIdx).map(k => `${k}:${scopeMaxIdx[k].value}`),
+			...filterDuplicates(unregistered),
+		];
 	}
 
 	// --- Service account elevation ---

--- a/permissions/frontend/src/main/modules/ModuleFE_PermissionsAssert.ts
+++ b/permissions/frontend/src/main/modules/ModuleFE_PermissionsAssert.ts
@@ -31,14 +31,21 @@ export class ModuleFE_PermissionsAssert_Class
 	hasScopeAccess(scope: PermissionScope, requiredValue: string): boolean {
 		const scopeEntries = ModuleFE_UserPermissions.getScopeEntries();
 		const prefix = scope.key + ':';
-		const entry = scopeEntries.find(p => p.startsWith(prefix));
-		if (!entry)
+		const requiredIdx = scope.values.indexOf(requiredValue);
+		if (requiredIdx < 0)
 			return false;
 
-		const userValue = entry.substring(prefix.length);
-		const requiredIdx = scope.values.indexOf(requiredValue);
-		const userIdx = scope.values.indexOf(userValue);
-		return userIdx >= requiredIdx;
+		let highestIdx = -1;
+		for (const entry of scopeEntries) {
+			if (!entry.startsWith(prefix))
+				continue;
+
+			const userIdx = scope.values.indexOf(entry.substring(prefix.length));
+			if (userIdx > highestIdx)
+				highestIdx = userIdx;
+		}
+
+		return highestIdx >= requiredIdx;
 	}
 }
 

--- a/ts-messaging/.rules/how-to-use.mdc
+++ b/ts-messaging/.rules/how-to-use.mdc
@@ -26,7 +26,7 @@ The ts-messaging lib provides a universal conversation primitive — entity-anch
 - **Permissions via per-topic entity groups.** On Topic create, `ModuleBE_MessagingAccess` mints four `entity` AccessGroups (`readers` / `writers` / `deleters` / `owners`) and stamps those IDs on `Topic.__access`. Messages **copy** that `__access` at create. The creator’s personal group is a member of all four. Static `AccessGroup_MessagingRead/Write/Delete/Admin` remain as optional **scope** roles (`@RequirePermission`), not document ACL.
 - **`message:create` is Topic.writers|owners.** A dedicated interceptor gates Message create (the permissions create interceptor only stamps). Message update requires the author (`_auditorId`) **or** Topic owners. Delete/read stay on the default deleters|owners and readers interceptors.
 - **Topic create owns membership.** Mint four entity groups and add the creator (and later conversation/project members at create time). Messages **copy Topic.__access** at create. `mention?` does **not** grant Topic ACL.
-- **`mention?` is optional directed-ask.** `DB_Account['_id'][]` when present. After a successful Message create with `(mention ?? []).length > 0`, dispatch `{topic, message, mentionedAccountIds}` once — `mentionedAccountIds` is the full `message.mention` array (not once-per-id). Omitted or empty `mention` does not dispatch (manual path). Set/update/delete do not dispatch. No listener = no-op. The library does not know Persona, LLM, or knowledge.
+- **`mention` is backend-owned.** Do not send `mention[]` from the UI. Do not persist client `mention[]`. On create, `resolveCreateMentions` stamps it: parse `@_id(<32-hex>)` from text; every token must be a topic writer other than the sender or the create is 400 (`Invalid mention`) — do not drop and continue. No tokens: 1:1 infers the other writer; multi stays empty. After a successful create with `(mention ?? []).length > 0`, dispatch `{topic, message, mentionedAccountIds}` once — full array, not once-per-id. Set/update/delete do not dispatch. No listener = no-op. The library does not know Persona, LLM, or knowledge. Persona wake is a second bar: access-filtered persona query in the listener — never unmanipulated.
 - **File attachments reference `DB_Asset` from file-upload.** The `AssetRef` type holds `{ assetId }` pointing to the file-upload library's asset collection.
 
 ---
@@ -285,6 +285,16 @@ if (!topic) {
 
 ---
 
+## Never ever (mentions)
+
+Changing these is a product defect. Architecture SSOT: `_docs/architecture/agent-consult.md` §8.1.
+
+- **Never persist or trust client `mention[]`.** The UI send path does not decide who was asked. Text may contain `@_id(<accountId>)` after `@name` resolve; `resolveCreateMentions` stamps `mention[]`.
+- **Never drop a bad `@_id` and continue.** Missing, other-org, not a topic writer, or the sender → 400, no row, no callback. One bad token fails the whole create.
+- **Never infer mentions on a multi-party topic.** No tokens → nobody is asked. 1:1 with no tokens infers the other writer.
+- **Never wake anyone by re-parsing Message.text after create.** Verdict is `mention[]` on the row.
+- **Never look up a persona unmanipulated to wake it.** Access-filtered query only.
+
 ## Forbidden patterns
 
 - **Do not create topics without an anchor** — every topic must have `anchor: { dbKey, id }`.
@@ -297,3 +307,5 @@ if (!topic) {
 - **Do not dispatch `OnMessageMentioned` once per mentioned id** — one dispatch per create, full `mentionedAccountIds`.
 - **Do not fire `OnMessageMentioned` from preWrite** — only `postWriteProcessing` after a successful create.
 - **Do not grant Topic ACL from `mention`** — membership is set at Topic create; messages copy Topic `__access`.
+- **Do not attach a mention in the UI send path** — see Never ever (mentions).
+- **Do not treat parsed `@_id` as authorized** — see Never ever (mentions).

--- a/ts-messaging/backend/src/main/ModuleBE_MessageDB.ts
+++ b/ts-messaging/backend/src/main/ModuleBE_MessageDB.ts
@@ -26,9 +26,19 @@ export class ModuleBE_MessageDB_Class
 		ModuleBE_MessagingAccess.wireMessage(this);
 	}
 
-	protected async preWriteProcessing(dbInstance: DatabaseDef_Message['uiType'], _originalDbInstance: DatabaseDef_Message['dbType']) {
+	protected async preWriteProcessing(dbInstance: DatabaseDef_Message['uiType'], originalDbInstance: DatabaseDef_Message['dbType']) {
 		if (!dbInstance._auditorId)
 			dbInstance._auditorId = await getAuditorId();
+
+		if (originalDbInstance)
+			return;
+
+		// Always overwrite. Client mention[] is not an allow-list — see resolveCreateMentions.
+		dbInstance.mention = await ModuleBE_MessagingAccess.resolveCreateMentions(
+			dbInstance.topicId,
+			dbInstance._auditorId,
+			dbInstance.text,
+		);
 	}
 
 	protected async postWriteProcessing(data: PostWriteProcessingDataShape<DatabaseDef_Message['dbType']>, actionType: CollectionActionType) {

--- a/ts-messaging/backend/src/main/messaging-access-wiring.ts
+++ b/ts-messaging/backend/src/main/messaging-access-wiring.ts
@@ -25,7 +25,8 @@ import {
 	ModuleBE_Permissions,
 } from '@nu-art/permissions-backend';
 import {MemKey_AccountId} from '@nu-art/user-account-backend';
-import type {DatabaseDef_Message, DatabaseDef_Topic} from '@nu-art/ts-messaging-shared';
+import type {DB_Account} from '@nu-art/user-account-shared';
+import {parseMessageMentionIds, type DatabaseDef_Message, type DatabaseDef_Topic} from '@nu-art/ts-messaging-shared';
 
 type AccessCarrier = {
 	__access?: DocumentAccessInner;
@@ -107,6 +108,41 @@ export class ModuleBE_MessagingAccess_Class
 
 		this.logWarning(`REJECTED: insufficient document access — topicId=${topicId} keys=${keys.join('|')}`);
 		throw HttpCodes._4XX.FORBIDDEN('Insufficient document access');
+	}
+
+	/**
+	 * Backend-owned mention allow-list. Do not "simplify" this.
+	 *
+	 * Client `mention[]` is ignored. `@_id(<accountId>)` in text is a claim.
+	 * A referenced account that is missing, not a topic writer, or the sender is a 400 —
+	 * do not drop it and continue. Mention never grants Topic ACL.
+	 *
+	 * Allow-list = topic writers other than the sender. Valid `@_id` tokens become mention[].
+	 * No tokens: 1:1 infers the other writer; multi stays empty.
+	 */
+	async resolveCreateMentions(
+		topicId: UniqueId,
+		senderAccountId: UniqueId,
+		text?: string,
+	): Promise<DB_Account['_id'][]> {
+		const writerIds = await this.listTopicWriterAccountIds(topicId);
+		const claimed = parseMessageMentionIds(text);
+		if (claimed.some(id => id === senderAccountId || !writerIds.has(id)))
+			throw HttpCodes._4XX.BAD_REQUEST('Invalid mention');
+
+		if (claimed.length)
+			return claimed as DB_Account['_id'][];
+
+		const others = [...writerIds].filter(id => id !== senderAccountId);
+		if (others.length === 1)
+			return [others[0] as DB_Account['_id']];
+
+		return [];
+	}
+
+	async listTopicWriterAccountIds(topicId: UniqueId): Promise<Set<string>> {
+		const group = await ModuleBE_AccessGroupDB.query.uniqueUnmanipulated(deriveEntityGroupId(topicId, 'writers'));
+		return new Set(group?.members ?? []);
 	}
 
 	async addAccountToTopic(topicId: UniqueId, accountId: UniqueId): Promise<void> {

--- a/ts-messaging/backend/src/main/messaging-access-wiring.ts
+++ b/ts-messaging/backend/src/main/messaging-access-wiring.ts
@@ -109,6 +109,16 @@ export class ModuleBE_MessagingAccess_Class
 		throw HttpCodes._4XX.FORBIDDEN('Insufficient document access');
 	}
 
+	async addAccountToTopic(topicId: UniqueId, accountId: UniqueId): Promise<void> {
+		const personalGroupId = stringToUniqueId<DatabaseDef_AccessGroup['dbKey']>(accountId);
+		await ModuleBE_Permissions.runAsSystemContext([], async () => {
+			for (const accessKey of AllDocumentAccessKeys) {
+				const groupId = await this.ensureEntityGroup(topicId, accessKey);
+				await this.addMemberGroupToAccessGroup(groupId, personalGroupId);
+			}
+		});
+	}
+
 	private async mintTopicGroups(topicId: UniqueId): Promise<void> {
 		const creatorPersonalGroupId = stringToUniqueId<DatabaseDef_AccessGroup['dbKey']>(MemKey_AccountId.get());
 

--- a/ts-messaging/backend/src/test/message-mention-dispatcher.test.firebase.ts
+++ b/ts-messaging/backend/src/test/message-mention-dispatcher.test.firebase.ts
@@ -1,5 +1,5 @@
 /*
- * @nu-art/ts-messaging-backend - OnMessageMentioned dispatcher after Message create
+ * @nu-art/ts-messaging-backend - mention resolve + OnMessageMentioned
  * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
  * Licensed under the Apache License, Version 2.0
  */
@@ -9,11 +9,14 @@ import {generateHex, Module} from '@nu-art/ts-common';
 import {ModuleBE_BaseDB} from '@nu-art/db-api-backend';
 import {stormTester} from '@nu-art/storm-testalot';
 import type {StormTestInput} from '@nu-art/storm-testalot';
+import {formatMessageMentionToken} from '@nu-art/ts-messaging-shared';
 import {ModuleBE_MessageDB} from '../main/ModuleBE_MessageDB.js';
+import {ModuleBE_MessagingAccess} from '../main/messaging-access-wiring.js';
 import type {MessageMentionedPayload, OnMessageMentioned} from '../main/dispatchers.js';
 import {
 	asAccount,
 	createTopicForTest,
+	expectBadRequest,
 	provisionAccounts,
 	StormTest_MessagingAcl,
 	TEST_MONGO_DB,
@@ -40,35 +43,115 @@ const StormTest_MentionDispatcher: StormTestInput = {
 ModuleBE_BaseDB.setDefaultBackend('mongo');
 ModuleBE_BaseDB.setMongoDbName(TEST_MONGO_DB);
 
-describe('ts-messaging OnMessageMentioned dispatcher', () => {
-	it('create with two mention ids dispatches once with both ids', async () => {
+describe('ts-messaging mention resolve + dispatcher', () => {
+	it('1:1 infers the other writer and dispatches — client mention[] is ignored', async () => {
 		await stormTester(StormTest_MentionDispatcher, async () => {
 			MentionSpy.calls = [];
-			const [creator, mentionedA, mentionedB] = await provisionAccounts(
+			const [creator, other, stranger] = await provisionAccounts(
 				`creator-${generateHex(8)}@test.local`,
-				`mentioned-a-${generateHex(8)}@test.local`,
-				`mentioned-b-${generateHex(8)}@test.local`,
+				`other-${generateHex(8)}@test.local`,
+				`stranger-${generateHex(8)}@test.local`,
 			);
-			const mention = [mentionedA._id, mentionedB._id];
 
 			const {topic, message} = await asAccount(creator, async () => {
 				const createdTopic = await createTopicForTest();
+				await ModuleBE_MessagingAccess.addAccountToTopic(createdTopic._id, other._id);
 				const createdMessage = await asAccount(creator, () => ModuleBE_MessageDB.create.item({
 					topicId: createdTopic._id,
-					text: 'hello two mentions',
-					mention,
+					text: 'plain 1:1 — no token',
+					mention: [stranger._id],
 				}));
 				return {topic: createdTopic, message: createdMessage};
 			});
 
+			expect(message.mention).to.deep.equal([other._id]);
 			expect(MentionSpy.calls).to.have.length(1);
-			expect(MentionSpy.calls[0].mentionedAccountIds).to.deep.equal(mention);
+			expect(MentionSpy.calls[0].mentionedAccountIds).to.deep.equal([other._id]);
 			expect(MentionSpy.calls[0].message._id).to.equal(message._id);
 			expect(MentionSpy.calls[0].topic._id).to.equal(topic._id);
 		});
 	});
 
-	it('create that omits mention does not dispatch', async () => {
+	it('multi-party without @_id does not infer or dispatch', async () => {
+		await stormTester(StormTest_MentionDispatcher, async () => {
+			MentionSpy.calls = [];
+			const [creator, a, b] = await provisionAccounts(
+				`creator-${generateHex(8)}@test.local`,
+				`a-${generateHex(8)}@test.local`,
+				`b-${generateHex(8)}@test.local`,
+			);
+
+			const message = await asAccount(creator, async () => {
+				const topic = await createTopicForTest();
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, a._id);
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, b._id);
+				return asAccount(creator, () => ModuleBE_MessageDB.create.item({
+					topicId: topic._id,
+					text: 'hey room',
+					mention: [a._id, b._id],
+				}));
+			});
+
+			expect(message.mention ?? []).to.deep.equal([]);
+			expect(MentionSpy.calls).to.have.length(0);
+		});
+	});
+
+	it('multi-party @_id of a writer dispatches that account', async () => {
+		await stormTester(StormTest_MentionDispatcher, async () => {
+			MentionSpy.calls = [];
+			const [creator, writer, peer] = await provisionAccounts(
+				`creator-${generateHex(8)}@test.local`,
+				`writer-${generateHex(8)}@test.local`,
+				`peer-${generateHex(8)}@test.local`,
+			);
+
+			const message = await asAccount(creator, async () => {
+				const topic = await createTopicForTest();
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, writer._id);
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, peer._id);
+				return asAccount(creator, () => ModuleBE_MessageDB.create.item({
+					topicId: topic._id,
+					text: `ask ${formatMessageMentionToken(writer._id)}`,
+				}));
+			});
+
+			expect(message.mention).to.deep.equal([writer._id]);
+			expect(MentionSpy.calls).to.have.length(1);
+			expect(MentionSpy.calls[0].mentionedAccountIds).to.deep.equal([writer._id]);
+		});
+	});
+
+	it('@_id of a missing or non-writer account rejects the create', async () => {
+		await stormTester(StormTest_MentionDispatcher, async () => {
+			MentionSpy.calls = [];
+			const [creator, writer, peer, outsider] = await provisionAccounts(
+				`creator-${generateHex(8)}@test.local`,
+				`writer-${generateHex(8)}@test.local`,
+				`peer-${generateHex(8)}@test.local`,
+				`outsider-${generateHex(8)}@test.local`,
+			);
+			const missingId = generateHex(32);
+
+			await asAccount(creator, async () => {
+				const topic = await createTopicForTest();
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, writer._id);
+				await ModuleBE_MessagingAccess.addAccountToTopic(topic._id, peer._id);
+				await expectBadRequest(() => asAccount(creator, () => ModuleBE_MessageDB.create.item({
+					topicId: topic._id,
+					text: `ask ${formatMessageMentionToken(writer._id)} and ${formatMessageMentionToken(outsider._id)}`,
+				})));
+				await expectBadRequest(() => asAccount(creator, () => ModuleBE_MessageDB.create.item({
+					topicId: topic._id,
+					text: `ask ${formatMessageMentionToken(missingId)}`,
+				})));
+			});
+
+			expect(MentionSpy.calls).to.have.length(0);
+		});
+	});
+
+	it('solo topic without @_id does not dispatch', async () => {
 		await stormTester(StormTest_MentionDispatcher, async () => {
 			MentionSpy.calls = [];
 			const [creator] = await provisionAccounts(`creator-${generateHex(8)}@test.local`);
@@ -78,24 +161,6 @@ describe('ts-messaging OnMessageMentioned dispatcher', () => {
 				await asAccount(creator, () => ModuleBE_MessageDB.create.item({
 					topicId: topic._id,
 					text: 'manual path — mention omitted',
-				}));
-			});
-
-			expect(MentionSpy.calls).to.have.length(0);
-		});
-	});
-
-	it('create with empty mention does not dispatch', async () => {
-		await stormTester(StormTest_MentionDispatcher, async () => {
-			MentionSpy.calls = [];
-			const [creator] = await provisionAccounts(`creator-${generateHex(8)}@test.local`);
-
-			await asAccount(creator, async () => {
-				const topic = await createTopicForTest();
-				await asAccount(creator, () => ModuleBE_MessageDB.create.item({
-					topicId: topic._id,
-					text: 'manual path — no mentions',
-					mention: [],
 				}));
 			});
 
@@ -113,7 +178,6 @@ describe('ts-messaging OnMessageMentioned dispatcher', () => {
 				const message = await asAccount(creator, () => ModuleBE_MessageDB.create.item({
 					topicId: topic._id,
 					text: 'original',
-					mention: [],
 				}));
 				MentionSpy.calls = [];
 				await ModuleBE_MessageDB.set.item({

--- a/ts-messaging/backend/src/test/utils/helpers.ts
+++ b/ts-messaging/backend/src/test/utils/helpers.ts
@@ -104,3 +104,13 @@ export async function expectForbidden(action: () => Promise<unknown>): Promise<v
 		expect((e as ApiException).responseCode).to.equal(403);
 	}
 }
+
+export async function expectBadRequest(action: () => Promise<unknown>): Promise<void> {
+	try {
+		await action();
+		expect.fail('expected ApiException');
+	} catch (e) {
+		expect(e).to.be.instanceOf(ApiException);
+		expect((e as ApiException).responseCode).to.equal(400);
+	}
+}

--- a/ts-messaging/frontend/src/main/ModuleFE_Message.ts
+++ b/ts-messaging/frontend/src/main/ModuleFE_Message.ts
@@ -30,13 +30,12 @@ export class ModuleFE_Message_Class
 		});
 	}
 
-	async createMessage(topicId: UniqueId, text?: string, attachments?: AssetRef[], parentMessageId?: UniqueId, mention?: DatabaseDef_Message['uiType']['mention']) {
+	async createMessage(topicId: UniqueId, text?: string, attachments?: AssetRef[], parentMessageId?: UniqueId) {
 		const newMessage: DatabaseDef_Message['uiType'] = {
 			topicId,
 			text,
 			attachments,
 			parentMessageId,
-			...(mention !== undefined ? {mention} : {}),
 		} as DatabaseDef_Message['uiType'];
 		return this.upsert(newMessage);
 	}

--- a/ts-messaging/shared/src/main/index.ts
+++ b/ts-messaging/shared/src/main/index.ts
@@ -1,5 +1,6 @@
 export * from './message/types.js';
 export * from './message/db-def.js';
+export * from './message-mention.js';
 export * from './topic/types.js';
 export * from './topic/db-def.js';
 export * from './api-def.js';

--- a/ts-messaging/shared/src/main/message-mention.ts
+++ b/ts-messaging/shared/src/main/message-mention.ts
@@ -1,0 +1,39 @@
+/*
+ * @nu-art/ts-messaging-shared — mention tokens in message text
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {dbIdLength} from '@nu-art/ts-common';
+import type {DB_Account} from '@nu-art/user-account-shared';
+
+/**
+ * Directed-ask token written into Message.text after the UI resolves `@name`.
+ * Backend parse is the only source of explicit mentions — never trust client `mention[]`.
+ *
+ * Do not treat `@name` as a mention here. Display names are not stable and are not an allow-list.
+ */
+export function formatMessageMentionToken(accountId: DB_Account['_id'] | string): string {
+	return `@_id(${accountId})`;
+}
+
+/**
+ * Extract claimed account ids from `@_id(<32-hex>)` tokens.
+ * Claims are not authorization — `resolveCreateMentions` must intersect with topic writers.
+ */
+export function parseMessageMentionIds(text?: string): string[] {
+	if (!text)
+		return [];
+
+	const ids: string[] = [];
+	const seen = new Set<string>();
+	const pattern = new RegExp(`@_id\\(([0-9a-f]{${dbIdLength}})\\)`, 'g');
+	for (const match of text.matchAll(pattern)) {
+		const id = match[1];
+		if (seen.has(id))
+			continue;
+		seen.add(id);
+		ids.push(id);
+	}
+	return ids;
+}

--- a/ts-messaging/shared/src/test/test.ts
+++ b/ts-messaging/shared/src/test/test.ts
@@ -1,3 +1,4 @@
 import './tests/topic-db-def.test.js';
 import './tests/message-db-def.test.js';
+import './tests/message-mention.test.js';
 import './tests/api-def.test.js';

--- a/ts-messaging/shared/src/test/tests/message-mention.test.ts
+++ b/ts-messaging/shared/src/test/tests/message-mention.test.ts
@@ -1,0 +1,25 @@
+import {formatMessageMentionToken, parseMessageMentionIds} from '../../main/message-mention.js';
+
+describe('parseMessageMentionIds', () => {
+	it('returns empty for omitted or plain text', () => {
+		if (parseMessageMentionIds(undefined).length !== 0)
+			throw new Error('Expected omitted text to parse as no mentions');
+		if (parseMessageMentionIds('hello @permissions').length !== 0)
+			throw new Error('Expected @name leftover to parse as no mentions');
+	});
+
+	it('extracts unique @_id tokens in order', () => {
+		const a = '0123456789abcdef0123456789abcdef';
+		const b = 'fedcba9876543210fedcba9876543210';
+		const text = `ask ${formatMessageMentionToken(a)} and ${formatMessageMentionToken(b)} and ${formatMessageMentionToken(a)}`;
+		const parsed = parseMessageMentionIds(text);
+		if (parsed.length !== 2 || parsed[0] !== a || parsed[1] !== b)
+			throw new Error(`Expected unique ordered ids, got ${JSON.stringify(parsed)}`);
+	});
+
+	it('ignores uppercase or short forged tokens', () => {
+		const parsed = parseMessageMentionIds('@_id(0123456789ABCDEF0123456789ABCDEF) @_id(not-an-id) @_id(abc)');
+		if (parsed.length !== 0)
+			throw new Error(`Expected fail-closed parse, got ${JSON.stringify(parsed)}`);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `@nu-art/e2e-harness` so products share one ensure / health / teardown layer instead of copying `@app/e2e-harness`.
- Products keep their own `@app/e2e` stack (mongo, Firebase emulators, backend) and journeys.

## Test plan
- [ ] `bai -t -nb -tt=pure -up=e2e-harness` (8 unit tests)
- [ ] Product consumer (`@app/e2e`) can import `E2EHarness` after pointing `_thunderstorm` at this revision


Made with [Cursor](https://cursor.com)