### PR TITLE
feat(e2e-harness): shared programmatic E2E stack bootstrap

### DIFF
--- a/e2e-harness/.gitignore
+++ b/e2e-harness/.gitignore
@@ -1,0 +1,17 @@
+# Global
+**/.DS_Store
+
+# Node
+node_modules
+
+# Thunderstorm
+dist
+dist-test
+docs
+build
+package.json
+package-lock.json
+config.ts
+src/main/tsconfig.json
+src/test/tsconfig.json
+.eslintrc.js

--- a/e2e-harness/LICENSE
+++ b/e2e-harness/LICENSE
@@ -1,0 +1,3 @@
+Apache License
+Version 2.0, January 2004
+Full license here: http://www.apache.org/licenses/LICENSE-2.0

--- a/e2e-harness/README.md
+++ b/e2e-harness/README.md
@@ -1,0 +1,42 @@
+# @nu-art/e2e-harness
+
+Abstract programmatic bootstrap for product E2E stacks. Products implement `startup.startStack` (mongo, Firebase emulators, Storm backend); this package only ensures, health-polls, and tears down.
+
+## Purpose
+
+`E2EHarness.ensure` makes a configured health URL reachable. It can reuse an already-running stack or call the product's `startStack` hook, then poll until GET succeeds. Tests must run via a single `bai -t -nb` — no manual pre-launch.
+
+Product journeys (password-auth HTTP, Playwright portals) live in `@app/e2e` (or similar), not here.
+
+## Usage
+
+```ts
+import {E2EHarness, type E2EHarnessConfig} from '@nu-art/e2e-harness';
+
+const config: E2EHarnessConfig = {
+	backendPackage: '@app/backend',
+	healthUrl: 'https://localhost:8102/',
+	reuseExistingStack: false,
+	startup: {
+		applyEnv: () => {
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED ??= '0';
+			process.env.BACKEND_PORT ??= '8102';
+		},
+		startStack: startProductE2EStack,
+	},
+};
+
+const handle = await E2EHarness.ensure(config);
+await handle.teardown();
+```
+
+Child processes spawned from BAI mocha must **delete `NODE_OPTIONS`**. BAI registers `ts-node/esm` and that crashes `firebase` CLI and `node dist/index.js`.
+
+## Public exports
+
+| Symbol | Role |
+|--------|------|
+| `E2EHarness` | `ensure`, `teardownActive` |
+| `E2EHarnessConfig` / `E2EHarnessHandle` / `E2EHarnessOwnedResources` / `E2EHarnessStartupHooks` | Config and session types |
+| `waitForHealthUrl`, `createFetchHealthProbe`, `HealthProbe` | Health polling |
+| `DEFAULT_READY_TIMEOUT_MS` (120s), `DEFAULT_POLL_INTERVAL_MS` (500ms) | Timing defaults |

--- a/e2e-harness/__package.json
+++ b/e2e-harness/__package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@nu-art/e2e-harness",
+	"version": "{{THUNDERSTORM_VERSION}}",
+	"description": "Abstract programmatic bootstrap for product E2E stacks (backend + emulators + health gates)",
+	"type": "module",
+	"keywords": [
+		"e2e",
+		"harness",
+		"test",
+		"thunderstorm",
+		"nu-art"
+	],
+	"homepage": "https://github.com/nu-art-js/thunderstorm",
+	"bugs": {
+		"url": "https://github.com/nu-art-js/thunderstorm/issues?q=is%3Aissue+label%3Ae2e-harness"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+ssh://git@github.com:nu-art-js/thunderstorm.git",
+		"directory": "_thunderstorm/e2e-harness"
+	},
+	"publishConfig": {
+		"directory": "dist",
+		"linkDirectory": true
+	},
+	"license": "Apache-2.0",
+	"author": "TacB0sS",
+	"scripts": {
+		"build": "tsc"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@nu-art/testalot": "?"
+	},
+	"unitConfig": {
+		"type": "typescript-lib"
+	},
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.js"
+		}
+	}
+}

--- a/e2e-harness/src/main/E2EHarness.ts
+++ b/e2e-harness/src/main/E2EHarness.ts
@@ -1,0 +1,93 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {
+	createFetchHealthProbe,
+	DEFAULT_POLL_INTERVAL_MS,
+	DEFAULT_READY_TIMEOUT_MS,
+	type HealthProbe,
+	waitForHealthUrl,
+} from './health-check.js';
+import type {E2EHarnessConfig, E2EHarnessHandle, E2EHarnessOwnedResources} from './types.js';
+
+class E2EHarnessSession implements E2EHarnessHandle {
+	constructor(
+		readonly config: Readonly<E2EHarnessConfig>,
+		readonly reusedExisting: boolean,
+		private readonly ownedTeardown?: () => Promise<void>,
+	) {}
+
+	async teardown(): Promise<void> {
+		if (this.ownedTeardown)
+			await this.ownedTeardown();
+		E2EHarness.clearActive(this);
+	}
+}
+
+/** Programmatic lifecycle for full product stacks (Storm backend + emulators + health gates). */
+export class E2EHarness {
+	private static active: E2EHarnessSession | undefined;
+
+	/**
+	 * Ensures the configured stack is reachable.
+	 * Reuses an already-running stack when the health URL responds.
+	 */
+	static async ensure(
+		config: E2EHarnessConfig,
+		probe: HealthProbe = createFetchHealthProbe(),
+	): Promise<E2EHarnessHandle> {
+		if (E2EHarness.active && await probe(config.healthUrl))
+			return E2EHarness.active;
+
+		config.startup?.applyEnv?.();
+
+		const reuseExisting = config.reuseExistingStack ?? true;
+		if (reuseExisting && await probe(config.healthUrl)) {
+			const handle = new E2EHarnessSession(config, true);
+			E2EHarness.active = handle;
+			return handle;
+		}
+
+		if (!config.startup?.startStack)
+			throw bootstrapNotImplementedError(config);
+
+		const owned = await config.startup.startStack();
+		await waitForHealthUrl(
+			config.healthUrl,
+			probe,
+			config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+			config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+		);
+		const handle = new E2EHarnessSession(config, false, resolveOwnedTeardown(owned));
+		E2EHarness.active = handle;
+		return handle;
+	}
+
+	/** Tear down the active harness session, if any. */
+	static async teardownActive(): Promise<void> {
+		await E2EHarness.active?.teardown();
+	}
+
+	static clearActive(session: E2EHarnessSession): void {
+		if (E2EHarness.active === session)
+			E2EHarness.active = undefined;
+	}
+}
+
+function resolveOwnedTeardown(owned: E2EHarnessOwnedResources | void): (() => Promise<void>) | undefined {
+	if (!owned?.teardown)
+		return undefined;
+	return owned.teardown.bind(owned);
+}
+
+function bootstrapNotImplementedError(config: E2EHarnessConfig): Error {
+	return new Error(
+		`E2E harness: programmatic bootstrap for ${config.backendPackage} is not implemented yet. ` +
+		`Implement startup.startStack in the consumer config. ` +
+		`Health URL: ${config.healthUrl}. ` +
+		'Tests must run via a single `bai -t -nb` command — no manual pre-launch.',
+	);
+}

--- a/e2e-harness/src/main/health-check.ts
+++ b/e2e-harness/src/main/health-check.ts
@@ -1,0 +1,42 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+export const DEFAULT_READY_TIMEOUT_MS = 120_000;
+export const DEFAULT_POLL_INTERVAL_MS = 500;
+
+/** Probe whether a health URL responds to GET. Injectable for unit tests. */
+export type HealthProbe = (url: string) => Promise<boolean>;
+
+export function createFetchHealthProbe(options?: {relaxTls?: boolean}): HealthProbe {
+	const relaxTls = options?.relaxTls ?? true;
+	return async (url: string) => {
+		if (relaxTls)
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED ??= '0';
+		const response = await fetch(url, {method: 'GET'}).catch(() => undefined);
+		return !!response;
+	};
+}
+
+export async function waitForHealthUrl(
+	url: string,
+	probe: HealthProbe,
+	timeoutMs: number = DEFAULT_READY_TIMEOUT_MS,
+	pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await probe(url))
+			return;
+		await sleep(pollIntervalMs);
+	}
+	throw new Error(
+		`E2E harness: health URL did not become reachable at ${url} within ${timeoutMs}ms.`,
+	);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/e2e-harness/src/main/index.ts
+++ b/e2e-harness/src/main/index.ts
@@ -1,0 +1,20 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+export {E2EHarness} from './E2EHarness.js';
+export {
+	createFetchHealthProbe,
+	DEFAULT_POLL_INTERVAL_MS,
+	DEFAULT_READY_TIMEOUT_MS,
+	waitForHealthUrl,
+	type HealthProbe,
+} from './health-check.js';
+export type {
+	E2EHarnessConfig,
+	E2EHarnessHandle,
+	E2EHarnessOwnedResources,
+	E2EHarnessStartupHooks,
+} from './types.js';

--- a/e2e-harness/src/main/types.ts
+++ b/e2e-harness/src/main/types.ts
@@ -1,0 +1,42 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+/** Resources owned by a harness-owned stack bootstrap (for teardown). */
+export type E2EHarnessOwnedResources = {
+	teardown: () => Promise<void>;
+};
+
+/** Consumer-provided hooks for env, ports, and programmatic stack start. */
+export type E2EHarnessStartupHooks = {
+	/** Apply env vars before bootstrap (ports, emulator hosts, TLS flags). */
+	applyEnv?: () => void;
+	/**
+	 * Start mongo/firebase/backend when the health URL is unreachable.
+	 * Return owned resources when this process spawned the stack.
+	 */
+	startStack?: () => Promise<E2EHarnessOwnedResources | void>;
+};
+
+/** Config injected by the product E2E consumer (e.g. `@app/e2e`). */
+export type E2EHarnessConfig = {
+	/** npm package key for the backend entry (documentation + future BAI integration). */
+	backendPackage: string;
+	/** GET URL polled until reachable (typically backend root over HTTPS). */
+	healthUrl: string;
+	readyTimeoutMs?: number;
+	pollIntervalMs?: number;
+	/** When false, always runs startup.startStack even if healthUrl already responds. Default true. */
+	reuseExistingStack?: boolean;
+	startup?: E2EHarnessStartupHooks;
+};
+
+/** Active harness session returned by {@link E2EHarness.ensure}. */
+export type E2EHarnessHandle = {
+	readonly config: Readonly<E2EHarnessConfig>;
+	/** True when an already-running stack was reused (e.g. human dev session). */
+	readonly reusedExisting: boolean;
+	teardown(): Promise<void>;
+};

--- a/e2e-harness/src/test/E2EHarness.test.ts
+++ b/e2e-harness/src/test/E2EHarness.test.ts
@@ -1,0 +1,89 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {expect} from 'chai';
+import {E2EHarness} from '../main/E2EHarness.js';
+import type {E2EHarnessConfig} from '../main/types.js';
+
+describe('E2EHarness', () => {
+	const baseConfig: E2EHarnessConfig = {
+		backendPackage: '@app/backend',
+		healthUrl: 'https://127.0.0.1:8102/',
+	};
+
+	afterEach(async () => {
+		await E2EHarness.teardownActive();
+	});
+
+	it('reuses an already reachable stack without calling startStack', async () => {
+		let startCalls = 0;
+		const handle = await E2EHarness.ensure({
+			...baseConfig,
+			startup: {
+				startStack: async () => {
+					startCalls++;
+				},
+			},
+		}, async () => true);
+
+		expect(handle.reusedExisting).to.be.true;
+		expect(startCalls).to.equal(0);
+	});
+
+	it('throws when stack is unreachable and startStack is missing', async () => {
+		try {
+			await E2EHarness.ensure(baseConfig, async () => false);
+			expect.fail('expected bootstrap error');
+		} catch (error) {
+			expect((error as Error).message).to.match(/not implemented yet/);
+			expect((error as Error).message).to.match(/no manual pre-launch/);
+		}
+	});
+
+	it('starts stack and waits for health when bootstrap hook is provided', async () => {
+		let started = false;
+		let probeCalls = 0;
+		const handle = await E2EHarness.ensure({
+			...baseConfig,
+			readyTimeoutMs: 1_000,
+			pollIntervalMs: 5,
+			startup: {
+				startStack: async () => {
+					started = true;
+				},
+			},
+		}, async () => {
+			probeCalls++;
+			return started;
+		});
+
+		expect(handle.reusedExisting).to.be.false;
+		expect(started).to.be.true;
+		expect(probeCalls).to.be.greaterThan(0);
+	});
+
+	it('teardown invokes owned resources from startStack', async () => {
+		let tornDown = false;
+		let stackStarted = false;
+		await E2EHarness.ensure({
+			...baseConfig,
+			startup: {
+				startStack: async () => {
+					stackStarted = true;
+					return {
+						teardown: async () => {
+							tornDown = true;
+						},
+					};
+				},
+			},
+		}, async () => stackStarted);
+
+		expect(stackStarted).to.be.true;
+		await E2EHarness.teardownActive();
+		expect(tornDown).to.be.true;
+	});
+});

--- a/e2e-harness/src/test/health-check.test.ts
+++ b/e2e-harness/src/test/health-check.test.ts
@@ -1,0 +1,57 @@
+/*
+ * @nu-art/e2e-harness - Abstract programmatic bootstrap for product E2E stacks
+ * Copyright (C) 2026 Adam van der Kruk aka TacB0sS
+ * Licensed under the Apache License, Version 2.0
+ */
+
+import {expect} from 'chai';
+import {DEFAULT_POLL_INTERVAL_MS, DEFAULT_READY_TIMEOUT_MS, waitForHealthUrl} from '../main/health-check.js';
+
+describe('E2E harness health-check', () => {
+	it('waitForHealthUrl resolves when probe succeeds immediately', async () => {
+		let calls = 0;
+		await waitForHealthUrl(
+			'https://example.test/',
+			async () => {
+				calls++;
+				return true;
+			},
+			1_000,
+			10,
+		);
+		expect(calls).to.equal(1);
+	});
+
+	it('waitForHealthUrl polls until probe succeeds', async () => {
+		let calls = 0;
+		await waitForHealthUrl(
+			'https://example.test/',
+			async () => {
+				calls++;
+				return calls >= 3;
+			},
+			1_000,
+			5,
+		);
+		expect(calls).to.equal(3);
+	});
+
+	it('waitForHealthUrl throws after timeout', async () => {
+		try {
+			await waitForHealthUrl(
+				'https://127.0.0.1:59999/',
+				async () => false,
+				50,
+				10,
+			);
+			expect.fail('expected timeout error');
+		} catch (error) {
+			expect((error as Error).message).to.match(/did not become reachable/);
+		}
+	});
+
+	it('exports stable default timing constants', () => {
+		expect(DEFAULT_READY_TIMEOUT_MS).to.equal(120_000);
+		expect(DEFAULT_POLL_INTERVAL_MS).to.equal(500);
+	});
+});


### PR DESCRIPTION
## Summary
- Cherry-pick `@nu-art/e2e-harness` from `main` (`8e6b945aa`) onto `dev` so products can share one ensure / health / teardown layer.
- Already on `main` via https://github.com/nu-art-js/thunderstorm/pull/58. `dev` is a strict ancestor of `main`; this PR is only the harness package, not a 78-commit fast-forward.

## Test plan
- [ ] `bai -t -nb -tt=pure -up=e2e-harness`
- [ ] Product consumer can import `E2EHarness` after pointing `_thunderstorm` at this revision


Made with [Cursor](https://cursor.com)